### PR TITLE
fix: codebase analysis findings 2026-04-04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Go
-dashboard
+# Go binary
+/dashboard
 *.exe
 *.dll
 *.so

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -91,7 +92,9 @@ func (s *Service) ValidateSession(sid string) (*User, error) {
 		return nil, fmt.Errorf("parse expiry: %w", err)
 	}
 	if time.Now().UTC().After(expires) {
-		s.db.Exec("DELETE FROM sessions WHERE id = ?", sid)
+		if _, err := s.db.Exec("DELETE FROM sessions WHERE id = ?", sid); err != nil {
+			log.Printf("failed to delete expired session %s: %v", sid, err)
+		}
 		return nil, ErrSessionExpired
 	}
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -9,27 +9,12 @@ type contextKey string
 
 const userContextKey contextKey = "user"
 
-func Middleware(authSvc *Service) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			cookie, err := r.Cookie("DASHBOARD_SESSID")
-			if err != nil {
-				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-				return
-			}
-
-			user, err := authSvc.ValidateSession(cookie.Value)
-			if err != nil {
-				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-				return
-			}
-
-			ctx := context.WithValue(r.Context(), userContextKey, user)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
+// WithUser stores a User in the request context.
+func WithUser(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, userContextKey, user)
 }
 
+// UserFromContext retrieves the User from a request context.
 func UserFromContext(ctx context.Context) *User {
 	user, _ := ctx.Value(userContextKey).(*User)
 	return user

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -103,8 +103,13 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 			}
 		}
 
+		id := c.Id
+		if len(id) > 12 {
+			id = id[:12]
+		}
+
 		containers[i] = Container{
-			ID:      c.Id[:12],
+			ID:      id,
 			Name:    name,
 			Image:   c.Image,
 			State:   c.State,

--- a/internal/collectors/logs.go
+++ b/internal/collectors/logs.go
@@ -2,8 +2,6 @@ package collectors
 
 import (
 	"bufio"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -205,56 +203,6 @@ func guessPriority(msg string) int {
 	}
 }
 
-func getString(m map[string]interface{}, key string) string {
-	if v, ok := m[key]; ok {
-		switch s := v.(type) {
-		case string:
-			return s
-		case float64:
-			return strconv.FormatFloat(s, 'f', -1, 64)
-		default:
-			return fmt.Sprintf("%v", s)
-		}
-	}
-	return ""
-}
-
-// ParseJournalJSON parses JSON output from journalctl (for future use when journalctl is available)
-func ParseJournalJSON(data []byte) []LogEntry {
-	var entries []LogEntry
-	for _, line := range splitLines(data) {
-		if len(line) == 0 {
-			continue
-		}
-
-		var raw map[string]interface{}
-		if err := json.Unmarshal(line, &raw); err != nil {
-			continue
-		}
-
-		pri := 6
-		if p, ok := raw["PRIORITY"]; ok {
-			switch v := p.(type) {
-			case string:
-				pri, _ = strconv.Atoi(v)
-			case float64:
-				pri = int(v)
-			}
-		}
-
-		entries = append(entries, LogEntry{
-			Timestamp:     getString(raw, "__REALTIME_TIMESTAMP"),
-			Unit:          getString(raw, "_SYSTEMD_UNIT"),
-			Message:       getString(raw, "MESSAGE"),
-			Priority:      pri,
-			PriorityLabel: priorityLabel(pri),
-			Hostname:      getString(raw, "_HOSTNAME"),
-			PID:           getString(raw, "_PID"),
-		})
-	}
-	return entries
-}
-
 func priorityLabel(p int) string {
 	switch p {
 	case 0:
@@ -278,19 +226,3 @@ func priorityLabel(p int) string {
 	}
 }
 
-func splitLines(data []byte) [][]byte {
-	var lines [][]byte
-	start := 0
-	for i, b := range data {
-		if b == '\n' {
-			if i > start {
-				lines = append(lines, data[start:i])
-			}
-			start = i + 1
-		}
-	}
-	if start < len(data) {
-		lines = append(lines, data[start:])
-	}
-	return lines
-}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,7 +35,7 @@ func New(cfg *config.Config, authSvc *auth.Service,
 	logColl *collectors.LogCollector,
 ) *Server {
 	hub := NewHub()
-	wsHandler := NewWSHandler(hub, authSvc, sysColl, dockerColl)
+	wsHandler := NewWSHandler(hub, authSvc, sysColl, dockerColl, cfg)
 
 	s := &Server{
 		cfg:        cfg,
@@ -117,7 +117,7 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// Auth wrapper
+// Auth wrapper — validates session and injects user into request context
 func (s *Server) withAuth(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cookie, err := r.Cookie("DASHBOARD_SESSID")
@@ -126,13 +126,14 @@ func (s *Server) withAuth(handler http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		_, err = s.authSvc.ValidateSession(cookie.Value)
+		user, err := s.authSvc.ValidateSession(cookie.Value)
 		if err != nil {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}
 
-		handler(w, r)
+		ctx := auth.WithUser(r.Context(), user)
+		handler(w, r.WithContext(ctx))
 	}
 }
 
@@ -185,8 +186,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
-	cookie, _ := r.Cookie("DASHBOARD_SESSID")
-	user, _ := s.authSvc.ValidateSession(cookie.Value)
+	user := auth.UserFromContext(r.Context())
 	writeJSON(w, http.StatusOK, user)
 }
 
@@ -195,7 +195,8 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSystemOverview(w http.ResponseWriter, r *http.Request) {
 	metrics, err := s.sysColl.Collect()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("system overview error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to collect system metrics"})
 		return
 	}
 	writeJSON(w, http.StatusOK, metrics)
@@ -208,7 +209,8 @@ func (s *Server) handleCPUHistory(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleNetwork(w http.ResponseWriter, r *http.Request) {
 	metrics, err := s.sysColl.CollectNetwork()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("network metrics error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to collect network metrics"})
 		return
 	}
 	writeJSON(w, http.StatusOK, metrics)
@@ -219,7 +221,8 @@ func (s *Server) handleNetwork(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDockerContainers(w http.ResponseWriter, r *http.Request) {
 	containers, err := s.dockerColl.ListContainers()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("docker containers error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list containers"})
 		return
 	}
 	writeJSON(w, http.StatusOK, containers)
@@ -230,7 +233,8 @@ func (s *Server) handleDockerContainers(w http.ResponseWriter, r *http.Request) 
 func (s *Server) handleFail2Ban(w http.ResponseWriter, r *http.Request) {
 	status, err := s.f2bColl.GetStatus()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("fail2ban status error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get fail2ban status"})
 		return
 	}
 	writeJSON(w, http.StatusOK, status)
@@ -243,10 +247,14 @@ func (s *Server) handleFail2BanBans(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
+	if limit > 1000 {
+		limit = 1000
+	}
 
 	events, err := s.f2bColl.GetRecentBans(limit)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("fail2ban bans error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get recent bans"})
 		return
 	}
 	writeJSON(w, http.StatusOK, events)
@@ -266,10 +274,14 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
+	if limit > 1000 {
+		limit = 1000
+	}
 
 	entries, err := s.logColl.GetLogs(unit, priority, limit)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		log.Printf("logs error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get logs"})
 		return
 	}
 	writeJSON(w, http.StatusOK, entries)
@@ -280,8 +292,17 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	publicDir := s.cfg.PublicDir
 
+	// Sanitize path to prevent directory traversal
+	cleaned := filepath.Clean("/" + r.URL.Path)
+	filePath := filepath.Join(publicDir, cleaned)
+	absPublic, _ := filepath.Abs(publicDir)
+	absFile, _ := filepath.Abs(filePath)
+	if !strings.HasPrefix(absFile, absPublic+string(os.PathSeparator)) && absFile != absPublic {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Try to serve the requested file
-	filePath := filepath.Join(publicDir, r.URL.Path)
 	if info, err := os.Stat(filePath); err == nil && !info.IsDir() {
 		http.ServeFile(w, r, filePath)
 		return

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,14 +12,22 @@ import (
 
 	"github.com/LiukScot/dashboard/internal/auth"
 	"github.com/LiukScot/dashboard/internal/collectors"
+	"github.com/LiukScot/dashboard/internal/config"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
+func newUpgrader(allowedOrigins string) websocket.Upgrader {
+	allowed := make(map[string]bool)
+	for _, o := range strings.Split(allowedOrigins, ",") {
+		allowed[strings.TrimSpace(o)] = true
+	}
+	return websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			return allowed[origin]
+		},
+	}
 }
 
 type Hub struct {
@@ -47,12 +56,16 @@ func (h *Hub) Unregister(conn *websocket.Conn) {
 
 func (h *Hub) Broadcast(data []byte) {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
+	var failed []*websocket.Conn
 	for conn := range h.clients {
 		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			go h.Unregister(conn)
+			failed = append(failed, conn)
 		}
+	}
+	h.mu.RUnlock()
+
+	for _, conn := range failed {
+		h.Unregister(conn)
 	}
 }
 
@@ -63,18 +76,20 @@ func (h *Hub) ClientCount() int {
 }
 
 type WSHandler struct {
-	hub       *Hub
-	authSvc   *auth.Service
-	sysColl   *collectors.SystemCollector
+	hub        *Hub
+	authSvc    *auth.Service
+	sysColl    *collectors.SystemCollector
 	dockerColl *collectors.DockerCollector
+	upgrader   websocket.Upgrader
 }
 
-func NewWSHandler(hub *Hub, authSvc *auth.Service, sysColl *collectors.SystemCollector, dockerColl *collectors.DockerCollector) *WSHandler {
+func NewWSHandler(hub *Hub, authSvc *auth.Service, sysColl *collectors.SystemCollector, dockerColl *collectors.DockerCollector, cfg *config.Config) *WSHandler {
 	return &WSHandler{
 		hub:        hub,
 		authSvc:    authSvc,
 		sysColl:    sysColl,
 		dockerColl: dockerColl,
+		upgrader:   newUpgrader(cfg.AllowedOrigins),
 	}
 }
 
@@ -85,7 +100,7 @@ func (ws *WSHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conn, err := upgrader.Upgrade(w, r, nil)
+	conn, err := ws.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Printf("ws upgrade error: %v", err)
 		return


### PR DESCRIPTION
Closes #11

## Summary
- **Security**: Fix WebSocket origin bypass (CSWSH), path traversal in static file handler, cap limit params to prevent OOM, sanitize error messages to prevent info leakage
- **Bugs**: Fix race condition in WebSocket Hub.Broadcast (concurrent writes + lock ordering), fix nil pointer risk in handleMe via context-based auth, add Docker container ID bounds check, log expired session DELETE errors
- **Code quality**: Remove dead code (getString, ParseJournalJSON, splitLines, unused Middleware), add WithUser context helper

## Test plan
- [ ] Verify WebSocket connections still work from allowed origins
- [ ] Verify static file serving still works (SPA fallback)
- [ ] Verify login/logout/me endpoints work correctly
- [ ] Verify Docker container list and stats work
- [ ] Check that `?limit=999999999` is capped to 1000

---
*Generato automaticamente da Codebase Analyst*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container ID handling for identifiers shorter than 12 characters.
  * Improved error handling for session cleanup operations.

* **Security**
  * Added path traversal protection for static file serving.
  * Implemented WebSocket origin validation for enhanced connection security.

* **Improvements**
  * Generic error messages displayed instead of raw error details.
  * Added query result limits (max 1,000) for ban and log retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->