### PR TITLE
fix: codebase analysis findings 2026-04-11

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	let { children }: Props = $props();
 	let user = $state<{ id: number; email: string } | null>(null);
 	let loading = $state(true);
+	let loginError = $state('');
 
 	onMount(async () => {
 		try {
@@ -42,18 +43,20 @@
 	<div class="h-screen flex items-center justify-center">
 		<form
 			class="bg-bg-card border border-border rounded-xl p-8 w-full max-w-sm"
-			onsubmit={async (e) => {
-				e.preventDefault();
-				const form = e.currentTarget;
-				const data = new FormData(form);
-				try {
-					await api.login(data.get('email') as string, data.get('password') as string);
-					user = await api.me();
-				} catch (err) {
-					// show error
-				}
-			}}
-		>
+				onsubmit={async (e) => {
+					e.preventDefault();
+					loginError = '';
+					const form = e.currentTarget;
+					const data = new FormData(form);
+					try {
+						await api.login(data.get('email') as string, data.get('password') as string);
+						user = await api.me();
+						loginError = '';
+					} catch (err) {
+						loginError = err instanceof Error ? err.message : 'Sign in failed';
+					}
+				}}
+			>
 			<h1 class="text-xl font-semibold mb-6 text-center">Dashboard</h1>
 			<input
 				name="email"
@@ -62,16 +65,19 @@
 				required
 				class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-3 text-sm focus:outline-none focus:border-accent transition-colors"
 			/>
-			<input
-				name="password"
-				type="password"
+				<input
+					name="password"
+					type="password"
 				placeholder="Password"
 				required
-				class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-4 text-sm focus:outline-none focus:border-accent transition-colors"
-			/>
-			<button
-				type="submit"
-				class="w-full bg-accent text-bg font-medium rounded-lg py-2.5 text-sm hover:opacity-90 transition-opacity cursor-pointer"
+					class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-4 text-sm focus:outline-none focus:border-accent transition-colors"
+				/>
+				{#if loginError}
+					<p class="mb-4 text-sm text-danger">{loginError}</p>
+				{/if}
+				<button
+					type="submit"
+					class="w-full bg-accent text-bg font-medium rounded-lg py-2.5 text-sm hover:opacity-90 transition-opacity cursor-pointer"
 			>
 				Sign in
 			</button>

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -42,6 +43,8 @@ type ContainerStats struct {
 type DockerCollector struct {
 	client *http.Client
 }
+
+const maxConcurrentStatsRequests = 4
 
 func NewDockerCollector(socketPath string) *DockerCollector {
 	return &DockerCollector{
@@ -205,17 +208,47 @@ func (d *DockerCollector) GetAllStats() ([]ContainerStats, error) {
 		return nil, err
 	}
 
-	var stats []ContainerStats
+	running := make([]Container, 0, len(containers))
 	for _, c := range containers {
 		if c.State != "running" {
 			continue
 		}
-		s, err := d.GetContainerStats(c.ID)
-		if err != nil {
-			continue
-		}
-		stats = append(stats, *s)
+		running = append(running, c)
 	}
 
-	return stats, nil
+	stats := make([]ContainerStats, len(running))
+	filled := make([]bool, len(running))
+	sem := make(chan struct{}, maxConcurrentStatsRequests)
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i, c := range running {
+		wg.Add(1)
+		go func(i int, c Container) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			s, err := d.GetContainerStats(c.ID)
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			stats[i] = *s
+			filled[i] = true
+			mu.Unlock()
+		}(i, c)
+	}
+	wg.Wait()
+
+	result := make([]ContainerStats, 0, len(running))
+	for i, ok := range filled {
+		if ok {
+			result = append(result, stats[i])
+		}
+	}
+
+	return result, nil
 }

--- a/internal/collectors/docker_test.go
+++ b/internal/collectors/docker_test.go
@@ -1,0 +1,88 @@
+package collectors
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetAllStatsCollectsRunningContainersInParallel(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/json", func(w http.ResponseWriter, r *http.Request) {
+		containers := []map[string]any{
+			{"Id": "aaaaaaaaaaaa1111", "Names": []string{"/alpha"}, "State": "running", "Status": "Up"},
+			{"Id": "bbbbbbbbbbbb2222", "Names": []string{"/beta"}, "State": "running", "Status": "Up"},
+			{"Id": "cccccccccccc3333", "Names": []string{"/gamma"}, "State": "running", "Status": "Up"},
+		}
+		if err := json.NewEncoder(w).Encode(containers); err != nil {
+			t.Fatalf("encode containers: %v", err)
+		}
+	})
+	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/stats") {
+			http.NotFound(w, r)
+			return
+		}
+
+		time.Sleep(150 * time.Millisecond)
+		stats := map[string]any{
+			"name": "test",
+			"cpu_stats": map[string]any{
+				"cpu_usage":        map[string]any{"total_usage": 200},
+				"system_cpu_usage": 400,
+				"online_cpus":      2,
+			},
+			"precpu_stats": map[string]any{
+				"cpu_usage":        map[string]any{"total_usage": 100},
+				"system_cpu_usage": 200,
+			},
+			"memory_stats": map[string]any{
+				"usage": 100,
+				"limit": 400,
+			},
+			"networks": map[string]any{
+				"eth0": map[string]any{"rx_bytes": 10, "tx_bytes": 20},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(stats); err != nil {
+			t.Fatalf("encode stats: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	addr := strings.TrimPrefix(server.URL, "http://")
+	collector := &DockerCollector{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "tcp", addr)
+				},
+			},
+			Timeout: time.Second,
+		},
+	}
+
+	start := time.Now()
+	stats, err := collector.GetAllStats()
+	if err != nil {
+		t.Fatalf("GetAllStats: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if len(stats) != 3 {
+		t.Fatalf("expected stats for 3 containers, got %d", len(stats))
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("expected parallel collection under 300ms, got %s", elapsed)
+	}
+}

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -127,7 +127,10 @@ func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 			continue
 		}
 
-		ts, err := time.Parse("2006-01-02 15:04:05,000", matches[1])
+		// fail2ban uses comma for milliseconds (e.g. "2024-01-15 10:30:45,123")
+		// Go's time.Parse uses dot for fractional seconds, so replace comma
+		tsStr := strings.Replace(matches[1], ",", ".", 1)
+		ts, err := time.Parse("2006-01-02 15:04:05.000", tsStr)
 		if err != nil {
 			continue
 		}

--- a/internal/collectors/fail2ban_test.go
+++ b/internal/collectors/fail2ban_test.go
@@ -1,0 +1,44 @@
+package collectors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetRecentBansParsesCommaMilliseconds(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	logFile := filepath.Join(logDir, "fail2ban.log")
+	line := "2026-04-20 12:34:56,789 fail2ban.actions [1234]: NOTICE [sshd] Ban 1.2.3.4\n"
+	if err := os.WriteFile(logFile, []byte(line), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	collector := NewFail2BanCollector(logDir)
+	events, err := collector.GetRecentBans(10)
+	if err != nil {
+		t.Fatalf("GetRecentBans: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 ban event, got %d", len(events))
+	}
+
+	want := time.Date(2026, 4, 20, 12, 34, 56, 789000000, time.UTC)
+	if !events[0].Timestamp.Equal(want) {
+		t.Fatalf("expected timestamp %s, got %s", want, events[0].Timestamp)
+	}
+
+	if events[0].Jail != "sshd" {
+		t.Fatalf("expected jail sshd, got %q", events[0].Jail)
+	}
+	if events[0].Action != "ban" {
+		t.Fatalf("expected action ban, got %q", events[0].Action)
+	}
+	if events[0].IP != "1.2.3.4" {
+		t.Fatalf("expected IP 1.2.3.4, got %q", events[0].IP)
+	}
+}

--- a/internal/collectors/system.go
+++ b/internal/collectors/system.go
@@ -143,7 +143,7 @@ func (c *SystemCollector) CollectNetwork() ([]NetworkMetrics, error) {
 		c.mu.Lock()
 		if prev, ok := c.netHistory[iface]; ok {
 			dt := now.Sub(prev.timestamp).Seconds()
-			if dt > 0 {
+			if dt > 0 && rxBytes >= prev.rxBytes && txBytes >= prev.txBytes {
 				nm.RxRate = float64(rxBytes-prev.rxBytes) / dt
 				nm.TxRate = float64(txBytes-prev.txBytes) / dt
 			}
@@ -203,6 +203,7 @@ func (c *SystemCollector) readCPU(m *SystemMetrics) error {
 				}
 			}
 
+			c.mu.Lock()
 			if c.prevCPUTotal > 0 {
 				dTotal := total - c.prevCPUTotal
 				dIdle := idle - c.prevCPUIdle
@@ -212,6 +213,7 @@ func (c *SystemCollector) readCPU(m *SystemMetrics) error {
 			}
 			c.prevCPUIdle = idle
 			c.prevCPUTotal = total
+			c.mu.Unlock()
 		}
 		if strings.HasPrefix(line, "cpu") && !strings.HasPrefix(line, "cpu ") {
 			cores++

--- a/internal/collectors/system_test.go
+++ b/internal/collectors/system_test.go
@@ -1,0 +1,35 @@
+package collectors
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestSystemCollectorReadCPUConcurrent(t *testing.T) {
+	procDir := t.TempDir()
+	stat := "cpu  100 20 30 400 5 6 7 8 9 10\ncpu0 50 10 15 200 2 3 4 5 6 7\n"
+	if err := os.WriteFile(filepath.Join(procDir, "stat"), []byte(stat), 0o644); err != nil {
+		t.Fatalf("write stat: %v", err)
+	}
+
+	collector := NewSystemCollector(procDir)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				var metrics SystemMetrics
+				if err := collector.readCPU(&metrics); err != nil {
+					t.Errorf("readCPU: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Open(dbPath string) (*sql.DB, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
 		return nil, fmt.Errorf("create db dir: %w", err)
 	}
 
@@ -18,6 +18,9 @@ func Open(dbPath string) (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
+
+	// SQLite supports only one concurrent writer; limit pool to avoid "database is locked"
+	db.SetMaxOpenConns(1)
 
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("ping db: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,6 +140,7 @@ func (s *Server) withAuth(handler http.HandlerFunc) http.HandlerFunc {
 // --- Auth handlers ---
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
 	var body struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
@@ -179,6 +180,8 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   s.cfg.CookieSecure,
+		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/LiukScot/dashboard/internal/auth"
+	"github.com/LiukScot/dashboard/internal/config"
+	"github.com/LiukScot/dashboard/internal/db"
+)
+
+func TestHandleLoginRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "dashboard.sqlite")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(database); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	srv := &Server{
+		cfg:     &config.Config{SessionTTL: 3600},
+		authSvc: auth.NewService(database, 3600),
+	}
+
+	password := strings.Repeat("x", 5000)
+	body := fmt.Sprintf(`{"email":"person@example.com","password":"%s"}`, password)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	res := httptest.NewRecorder()
+
+	srv.handleLogin(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 for oversized body, got %d", res.Code)
+	}
+}
+
+func TestHubBroadcastConcurrentDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	upgrader := websocket.Upgrader{}
+	serverConnCh := make(chan *websocket.Conn, 1)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	t.Cleanup(httpServer.Close)
+
+	clientConn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpServer.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serverConn := <-serverConnCh
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, _, err := clientConn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	hub := NewHub()
+	hub.Register(serverConn)
+
+	panicCh := make(chan any, 1)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	writer := func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				select {
+				case panicCh <- r:
+				default:
+				}
+			}
+		}()
+
+		<-start
+		for i := 0; i < 100; i++ {
+			hub.Broadcast([]byte("payload"))
+		}
+	}
+
+	for range 4 {
+		wg.Add(1)
+		go writer()
+	}
+	close(start)
+	wg.Wait()
+
+	select {
+	case p := <-panicCh:
+		t.Fatalf("broadcast panicked: %v", p)
+	default:
+	}
+
+	_ = clientConn.Close()
+	<-done
+}

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -30,42 +30,54 @@ func newUpgrader(allowedOrigins string) websocket.Upgrader {
 	}
 }
 
+// connWithMu wraps a websocket.Conn with a write mutex to prevent
+// concurrent WriteMessage calls (gorilla/websocket requires this).
+type connWithMu struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
 type Hub struct {
 	mu      sync.RWMutex
-	clients map[*websocket.Conn]bool
+	clients map[*connWithMu]bool
 }
 
 func NewHub() *Hub {
 	return &Hub{
-		clients: make(map[*websocket.Conn]bool),
+		clients: make(map[*connWithMu]bool),
 	}
 }
 
-func (h *Hub) Register(conn *websocket.Conn) {
+func (h *Hub) Register(conn *websocket.Conn) *connWithMu {
+	c := &connWithMu{conn: conn}
 	h.mu.Lock()
-	h.clients[conn] = true
+	h.clients[c] = true
 	h.mu.Unlock()
+	return c
 }
 
-func (h *Hub) Unregister(conn *websocket.Conn) {
+func (h *Hub) Unregister(c *connWithMu) {
 	h.mu.Lock()
-	delete(h.clients, conn)
+	delete(h.clients, c)
 	h.mu.Unlock()
-	conn.Close()
+	c.conn.Close()
 }
 
 func (h *Hub) Broadcast(data []byte) {
 	h.mu.RLock()
-	var failed []*websocket.Conn
-	for conn := range h.clients {
-		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			failed = append(failed, conn)
+	var failed []*connWithMu
+	for c := range h.clients {
+		c.mu.Lock()
+		err := c.conn.WriteMessage(websocket.TextMessage, data)
+		c.mu.Unlock()
+		if err != nil {
+			failed = append(failed, c)
 		}
 	}
 	h.mu.RUnlock()
 
-	for _, conn := range failed {
-		h.Unregister(conn)
+	for _, c := range failed {
+		h.Unregister(c)
 	}
 }
 
@@ -106,11 +118,11 @@ func (ws *WSHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws.hub.Register(conn)
+	c := ws.hub.Register(conn)
 	log.Printf("ws client connected (%d total)", ws.hub.ClientCount())
 
 	go func() {
-		defer ws.hub.Unregister(conn)
+		defer ws.hub.Unregister(c)
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				break


### PR DESCRIPTION
Closes #13

## Summary

### Security
- **WebSocket race condition** (critical): Added per-connection write mutex to prevent concurrent `WriteMessage` calls
- **CPU data race** (critical): Protected `prevCPUIdle`/`prevCPUTotal` with existing mutex in `readCPU()`
- **Login body size limit**: Added `http.MaxBytesReader` (4KB cap) to prevent memory exhaustion
- **Logout cookie flags**: Added missing `Secure` and `SameSite` attributes
- **DB directory permissions**: Tightened from 0755 to 0700

### Bugs
- **Fail2ban timestamp parsing**: Fixed Go time format — comma replaced with dot for fractional seconds (all events were silently skipped)
- **Network rate underflow**: Added guard against uint64 wrap on counter reset

### Performance
- **SQLite connection pool**: Set `MaxOpenConns(1)` to prevent "database is locked" errors

## Test plan
- [ ] Verify WebSocket metrics still broadcast correctly with multiple clients
- [ ] Confirm fail2ban recent bans endpoint returns events (was broken before)
- [ ] Check login still works and rejects oversized bodies
- [ ] Verify logout properly clears cookie

---
*Generato automaticamente da Codebase Analyst*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fail2ban timestamp parsing with comma milliseconds
  * Prevented invalid network rate calculations when counters regress
  * Ensured thread-safe WebSocket writes and CPU metric reads

* **Security**
  * Tightened database directory permissions
  * Added request size limits to login endpoint
  * Strengthened logout cookie attributes

* **Improvements**
  * Constrained DB connections for SQLite
  * Gathered container stats concurrently for faster collection

* **Tests**
  * Added concurrency and parsing tests for collectors, server, and Docker stats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->