### PR TITLE
Add cron weekly calendar and hide settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Smoke test app
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl --fail --silent http://127.0.0.1:4200/api/v1/auth/session >/tmp/session.json; then
               break
             fi

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -139,6 +139,8 @@ export interface SessionResponse {
 export interface CronWeek {
 	start: string;
 	end: string;
+	days: string[];
+	timezone: string;
 	historyCoverage: 'none' | 'partial' | 'good';
 	hiddenJobCount: number;
 	jobs: CronJob[];
@@ -160,6 +162,9 @@ export interface CronOccurrence {
 	id: string;
 	jobId: string;
 	scheduledAt: string;
+	dayKey: string;
+	minutesOfDay: number;
+	displayTime: string;
 	status: 'planned' | 'scheduled' | 'observed' | 'failed';
 	source: string;
 	user: string;

--- a/frontend/src/routes/cron/+page.svelte
+++ b/frontend/src/routes/cron/+page.svelte
@@ -4,6 +4,7 @@
 
 	const hours = Array.from({ length: 24 }, (_, hour) => hour);
 	const dayNames = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+	let loadToken = 0;
 
 	let weekStart = $state(startOfWeek(new Date()));
 	let week = $state<CronWeek | null>(null);
@@ -15,17 +16,23 @@
 	onMount(loadWeek);
 
 	async function loadWeek() {
+		const token = ++loadToken;
+		const requestedWeekStart = weekStart;
 		loading = true;
 		error = '';
 		hideError = '';
 		try {
-			week = await api.cronWeek(toDateInput(weekStart));
-			selected = week.occurrences[0] ?? null;
+			const nextWeek = await api.cronWeek(toDateInput(requestedWeekStart));
+			if (token !== loadToken) return;
+			week = nextWeek;
+			selected = nextWeek.occurrences[0] ?? null;
 		} catch (err) {
+			if (token !== loadToken) return;
 			error = err instanceof Error ? err.message : 'Failed to load cron week';
 			week = null;
 			selected = null;
 		} finally {
+			if (token !== loadToken) return;
 			loading = false;
 		}
 	}
@@ -52,17 +59,16 @@
 	}
 
 	function daysInWeek() {
-		return Array.from({ length: 7 }, (_, index) => addDays(weekStart, index));
+		return week?.days ?? Array.from({ length: 7 }, (_, index) => toDateInput(addDays(weekStart, index)));
 	}
 
-	function occurrencesForDay(day: Date) {
+	function occurrencesForDay(dayKey: string) {
 		if (!week) return [];
-		return week.occurrences.filter((occurrence) => sameDay(new Date(occurrence.scheduledAt), day));
+		return week.occurrences.filter((occurrence) => occurrence.dayKey === dayKey);
 	}
 
 	function occurrenceStyle(occurrence: CronOccurrence) {
-		const when = new Date(occurrence.scheduledAt);
-		const top = ((when.getHours() * 60 + when.getMinutes()) / 1440) * 100;
+		const top = (occurrence.minutesOfDay / 1440) * 100;
 		return `top: ${top}%;`;
 	}
 
@@ -83,12 +89,17 @@
 		return `${String(hour).padStart(2, '0')}:00`;
 	}
 
-	function formatTime(value: string) {
-		return new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	function formatTimeLabel(occurrence: CronOccurrence) {
+		return occurrence.displayTime;
 	}
 
-	function formatDate(value: Date) {
-		return value.toLocaleDateString([], { month: 'short', day: 'numeric' });
+	function formatScheduledLabel(occurrence: CronOccurrence) {
+		return `${formatDate(occurrence.dayKey)}, ${occurrence.displayTime}`;
+	}
+
+	function formatDate(value: string) {
+		const [year, month, day] = value.split('-').map(Number);
+		return new Date(year, month - 1, day).toLocaleDateString([], { month: 'short', day: 'numeric' });
 	}
 
 	function weekTitle() {
@@ -109,10 +120,6 @@
 		const date = new Date(value);
 		date.setDate(date.getDate() + days);
 		return date;
-	}
-
-	function sameDay(a: Date, b: Date) {
-		return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 	}
 
 	function toDateInput(value: Date) {
@@ -196,9 +203,9 @@
 				<div class="grid grid-cols-[58px_repeat(7,minmax(128px,1fr))] border-b border-border">
 					<div class="border-r border-border"></div>
 					{#each daysInWeek() as day, index}
-						<div class="border-r border-border px-3 py-2 last:border-r-0 {sameDay(day, new Date()) ? 'bg-accent/5' : ''}">
+						<div class="border-r border-border px-3 py-2 last:border-r-0 {day === toDateInput(new Date()) ? 'bg-accent/5' : ''}">
 							<div class="text-xs font-semibold text-text-dim">{dayNames[index]}</div>
-							<div class="text-xl font-semibold {sameDay(day, new Date()) ? 'text-accent' : 'text-text'}">{formatDate(day)}</div>
+							<div class="text-xl font-semibold {day === toDateInput(new Date()) ? 'text-accent' : 'text-text'}">{formatDate(day)}</div>
 						</div>
 					{/each}
 				</div>
@@ -228,7 +235,7 @@
 										onclick={() => (selected = occurrence)}
 										title={occurrence.command}
 									>
-										<div class="font-mono text-text-dim">{formatTime(occurrence.scheduledAt)}</div>
+											<div class="font-mono text-text-dim">{formatTimeLabel(occurrence)}</div>
 										<div class="truncate font-medium">{shortCommand(occurrence.command)}</div>
 									</button>
 								{/each}
@@ -265,7 +272,7 @@
 					<dl class="space-y-3 text-sm">
 						<div>
 							<dt class="text-xs text-text-dim">Scheduled</dt>
-							<dd>{new Date(selected.scheduledAt).toLocaleString()}</dd>
+							<dd>{formatScheduledLabel(selected)}</dd>
 						</div>
 						<div>
 							<dt class="text-xs text-text-dim">Command</dt>

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -31,13 +31,16 @@ type CronJob struct {
 }
 
 type CronOccurrence struct {
-	ID          string `json:"id"`
-	JobID       string `json:"jobId"`
-	ScheduledAt string `json:"scheduledAt"`
-	Status      string `json:"status"`
-	Source      string `json:"source"`
-	User        string `json:"user"`
-	Command     string `json:"command"`
+	ID           string `json:"id"`
+	JobID        string `json:"jobId"`
+	ScheduledAt  string `json:"scheduledAt"`
+	DayKey       string `json:"dayKey"`
+	MinutesOfDay int    `json:"minutesOfDay"`
+	DisplayTime  string `json:"displayTime"`
+	Status       string `json:"status"`
+	Source       string `json:"source"`
+	User         string `json:"user"`
+	Command      string `json:"command"`
 }
 
 type CronHistoryItem struct {
@@ -52,6 +55,8 @@ type CronHistoryItem struct {
 type CronWeek struct {
 	Start           string            `json:"start"`
 	End             string            `json:"end"`
+	Days            []string          `json:"days"`
+	Timezone        string            `json:"timezone"`
 	HistoryCoverage string            `json:"historyCoverage"`
 	HiddenJobCount  int               `json:"hiddenJobCount"`
 	Jobs            []CronJob         `json:"jobs"`
@@ -91,6 +96,8 @@ func (c *CronCollector) Week(start time.Time) (CronWeek, error) {
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("hidden jobs: %v", err))
 		} else {
+			current := jobSet(jobs)
+			hidden = c.pruneStaleHidden(hidden, current)
 			hiddenCount = len(hidden)
 			jobs = visibleJobs(jobs, hidden)
 		}
@@ -105,13 +112,16 @@ func (c *CronCollector) Week(start time.Time) (CronWeek, error) {
 		}
 		for _, when := range expr.occurrences(weekStart, weekEnd) {
 			occurrences = append(occurrences, CronOccurrence{
-				ID:          job.Fingerprint + "-" + when.Format("200601021504"),
-				JobID:       job.Fingerprint,
-				ScheduledAt: when.Format(time.RFC3339),
-				Status:      statusForOccurrence(when),
-				Source:      job.Source,
-				User:        job.User,
-				Command:     job.Command,
+				ID:           job.Fingerprint + "-" + when.Format("200601021504"),
+				JobID:        job.Fingerprint,
+				ScheduledAt:  when.Format(time.RFC3339),
+				DayKey:       when.Format("2006-01-02"),
+				MinutesOfDay: when.Hour()*60 + when.Minute(),
+				DisplayTime:  when.Format("15:04"),
+				Status:       statusForOccurrence(when),
+				Source:       job.Source,
+				User:         job.User,
+				Command:      job.Command,
 			})
 		}
 	}
@@ -165,6 +175,8 @@ func (c *CronCollector) Week(start time.Time) (CronWeek, error) {
 	return CronWeek{
 		Start:           weekStart.Format("2006-01-02"),
 		End:             weekEnd.Add(-time.Second).Format("2006-01-02"),
+		Days:            dayKeys(weekStart, 7),
+		Timezone:        weekStart.Location().String(),
 		HistoryCoverage: coverage,
 		HiddenJobCount:  hiddenCount,
 		Jobs:            jobs,
@@ -233,9 +245,13 @@ func (c *CronCollector) HiddenJobCount() (int, error) {
 	if c.db == nil {
 		return 0, fmt.Errorf("database unavailable")
 	}
-	var count int
-	err := c.db.QueryRow(`SELECT COUNT(*) FROM cron_hidden_jobs`).Scan(&count)
-	return count, err
+	jobs, _ := c.ReadJobs()
+	hidden, err := c.hiddenJobIDs()
+	if err != nil {
+		return 0, err
+	}
+	hidden = c.pruneStaleHidden(hidden, jobSet(jobs))
+	return len(hidden), nil
 }
 
 func (c *CronCollector) hiddenJobIDs() (map[string]bool, error) {
@@ -264,6 +280,28 @@ func visibleJobs(jobs []CronJob, hidden map[string]bool) []CronJob {
 		}
 	}
 	return visible
+}
+
+func jobSet(jobs []CronJob) map[string]bool {
+	current := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		current[job.Fingerprint] = true
+	}
+	return current
+}
+
+func (c *CronCollector) pruneStaleHidden(hidden map[string]bool, current map[string]bool) map[string]bool {
+	active := map[string]bool{}
+	for fingerprint := range hidden {
+		if current[fingerprint] {
+			active[fingerprint] = true
+			continue
+		}
+		if c.db != nil {
+			_, _ = c.db.Exec(`DELETE FROM cron_hidden_jobs WHERE job_id = ?`, fingerprint)
+		}
+	}
+	return active
 }
 
 func (c *CronCollector) resolveFiles() ([]string, []string) {
@@ -304,17 +342,31 @@ func parseCronLine(raw string, source string, lineNo int) (CronJob, bool, string
 		return CronJob{}, false, ""
 	}
 	fields := strings.Fields(line)
-	if len(fields) < 6 || strings.HasPrefix(fields[0], "@") {
+	if len(fields) < 2 {
 		return CronJob{}, false, ""
 	}
 
-	schedule := strings.Join(fields[:5], " ")
+	scheduleFields, warning := normalizeScheduleFields(fields[0])
+	if warning != "" {
+		return CronJob{}, false, fmt.Sprintf("skip %s:%d: %s", source, lineNo, warning)
+	}
+
 	commandStart := 5
 	user := ""
-	if usesSystemCronUser(source) && len(fields) >= 7 {
+	if len(scheduleFields) > 0 {
+		fields = append(scheduleFields, fields[1:]...)
+	}
+	if len(fields) < 6 {
+		return CronJob{}, false, fmt.Sprintf("skip %s:%d: malformed cron line", source, lineNo)
+	}
+	if usesSystemCronUser(source) {
+		if len(fields) < 7 {
+			return CronJob{}, false, fmt.Sprintf("skip %s:%d: missing cron user", source, lineNo)
+		}
 		user = fields[5]
 		commandStart = 6
 	}
+	schedule := strings.Join(fields[:5], " ")
 	command := strings.Join(fields[commandStart:], " ")
 	if command == "" {
 		return CronJob{}, false, fmt.Sprintf("skip %s:%d: missing command", source, lineNo)
@@ -328,6 +380,25 @@ func parseCronLine(raw string, source string, lineNo int) (CronJob, bool, string
 		Command:     command,
 	}
 	return job, true, ""
+}
+
+func normalizeScheduleFields(first string) ([]string, string) {
+	if !strings.HasPrefix(first, "@") {
+		return nil, ""
+	}
+	nicknames := map[string]string{
+		"@yearly":   "0 0 1 1 *",
+		"@annually": "0 0 1 1 *",
+		"@monthly":  "0 0 1 * *",
+		"@weekly":   "0 0 * * 0",
+		"@daily":    "0 0 * * *",
+		"@midnight": "0 0 * * *",
+		"@hourly":   "0 * * * *",
+	}
+	if expanded, ok := nicknames[strings.ToLower(first)]; ok {
+		return strings.Fields(expanded), ""
+	}
+	return nil, fmt.Sprintf("unsupported cron nickname %q", first)
 }
 
 func usesSystemCronUser(source string) bool {
@@ -345,6 +416,8 @@ func parseCronExpr(raw string) (cronExpr, error) {
 	if len(fields) != 5 {
 		return cronExpr{}, fmt.Errorf("expected 5 fields")
 	}
+	fields[3] = normalizeNamedField(fields[3], monthNames)
+	fields[4] = normalizeNamedField(fields[4], weekdayNames)
 	minutes, _, err := parseCronField(fields[0], 0, 59)
 	if err != nil {
 		return cronExpr{}, fmt.Errorf("minute: %w", err)
@@ -372,6 +445,23 @@ func parseCronExpr(raw string) (cronExpr, error) {
 	}
 	dow = uniqueSorted(dow)
 	return cronExpr{minutes: minutes, hours: hours, dom: dom, months: months, dow: dow, domWildcard: domWildcard, dowWildcard: dowWildcard}, nil
+}
+
+var monthNames = map[string]string{
+	"jan": "1", "feb": "2", "mar": "3", "apr": "4", "may": "5", "jun": "6",
+	"jul": "7", "aug": "8", "sep": "9", "oct": "10", "nov": "11", "dec": "12",
+}
+
+var weekdayNames = map[string]string{
+	"sun": "0", "mon": "1", "tue": "2", "wed": "3", "thu": "4", "fri": "5", "sat": "6",
+}
+
+func normalizeNamedField(raw string, mapping map[string]string) string {
+	result := strings.ToLower(raw)
+	for name, value := range mapping {
+		result = strings.ReplaceAll(result, name, value)
+	}
+	return result
 }
 
 func parseCronField(raw string, min int, max int) ([]int, bool, error) {
@@ -543,6 +633,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 	if c.logPath == "" {
 		return 0, nil
 	}
+	reference := end.Add(-time.Second)
 	byCommand := map[string]CronJob{}
 	for _, job := range jobs {
 		key := historyKey(job.User, job.Command)
@@ -571,7 +662,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 		}
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			observedAt, user, command, ok := parseCronLogLine(scanner.Text(), time.Now())
+			observedAt, user, command, ok := parseCronLogLine(scanner.Text(), reference)
 			if !ok || observedAt.Before(start) || !observedAt.Before(end) {
 				continue
 			}
@@ -612,7 +703,7 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 	imported := 0
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
-		observedAt, user, command, ok := parseCronLogLine(scanner.Text(), time.Now())
+		observedAt, user, command, ok := parseCronLogLine(scanner.Text(), end.Add(-time.Second))
 		if !ok || observedAt.Before(start) || !observedAt.Before(end) {
 			continue
 		}
@@ -686,9 +777,10 @@ func historyKey(user string, command string) string {
 	return strings.TrimSpace(user) + "\x00" + strings.TrimSpace(command)
 }
 
-func plural(count int) string {
-	if count == 1 {
-		return ""
+func dayKeys(start time.Time, count int) []string {
+	days := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		days = append(days, start.AddDate(0, 0, i).Format("2006-01-02"))
 	}
-	return "s"
+	return days
 }

--- a/internal/collectors/cron_test.go
+++ b/internal/collectors/cron_test.go
@@ -45,6 +45,21 @@ func TestParseCronExprExpandsWeeklyOccurrences(t *testing.T) {
 	}
 }
 
+func TestParseCronExprSupportsNamedWeekday(t *testing.T) {
+	t.Parallel()
+
+	expr, err := parseCronExpr("0 9 * * sun")
+	if err != nil {
+		t.Fatalf("parse expr: %v", err)
+	}
+
+	start := time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC)
+	got := expr.occurrences(start, start.AddDate(0, 0, 7))
+	if len(got) != 1 || got[0].Weekday() != time.Sunday {
+		t.Fatalf("expected one Sunday occurrence, got %#v", got)
+	}
+}
+
 func TestCronCollectorReadsCronFiles(t *testing.T) {
 	t.Parallel()
 
@@ -64,6 +79,21 @@ func TestCronCollectorReadsCronFiles(t *testing.T) {
 	}
 	if jobs[0].Command != "/bin/echo hello" {
 		t.Fatalf("unexpected command %q", jobs[0].Command)
+	}
+}
+
+func TestParseCronLineSupportsHourlyNickname(t *testing.T) {
+	t.Parallel()
+
+	job, ok, warning := parseCronLine("@hourly root /usr/local/bin/hourly-task", "/etc/cron.d/custom", 3)
+	if !ok {
+		t.Fatalf("expected nickname line to parse, warning %q", warning)
+	}
+	if job.Schedule != "0 * * * *" {
+		t.Fatalf("unexpected schedule %q", job.Schedule)
+	}
+	if job.User != "root" {
+		t.Fatalf("unexpected user %q", job.User)
 	}
 }
 
@@ -135,5 +165,59 @@ func TestCronCollectorHidesJobsFromWeek(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("expected hidden count 0, got %d", count)
+	}
+}
+
+func TestCronCollectorPrunesStaleHiddenJobs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "dashboard.sqlite")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := db.RunMigrations(database); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	cronPath := filepath.Join(dir, "crontab")
+	if err := os.WriteFile(cronPath, []byte("0 * * * * root run-parts /etc/cron.hourly\n"), 0600); err != nil {
+		t.Fatalf("write crontab: %v", err)
+	}
+
+	collector := NewCronCollector(database, []string{cronPath}, "")
+	week, err := collector.Week(time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("load week: %v", err)
+	}
+	if err := collector.HideJob(week.Jobs[0].Fingerprint); err != nil {
+		t.Fatalf("hide job: %v", err)
+	}
+
+	if err := os.WriteFile(cronPath, []byte("15 * * * * root /usr/local/bin/backup\n"), 0600); err != nil {
+		t.Fatalf("rewrite crontab: %v", err)
+	}
+
+	count, err := collector.HiddenJobCount()
+	if err != nil {
+		t.Fatalf("count hidden jobs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected stale hidden job to be pruned, got %d", count)
+	}
+}
+
+func TestParseCronLogLineUsesRequestedWeekYear(t *testing.T) {
+	t.Parallel()
+
+	reference := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	observedAt, _, _, ok := parseCronLogLine("Dec 31 23:59:59 host CRON[123]: (root) CMD (/usr/local/bin/backup)", reference)
+	if !ok {
+		t.Fatal("expected cron log line to parse")
+	}
+	if observedAt.Year() != 2024 {
+		t.Fatalf("expected prior year inference, got %s", observedAt.Format(time.RFC3339))
 	}
 }

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -21,7 +21,8 @@ trap cleanup EXIT
 for _ in $(seq 1 60); do
 	if curl --silent --fail http://127.0.0.1:4200/api/v1/auth/session >/dev/null; then
 		cd frontend
-		exec bun run dev --host 0.0.0.0
+		bun run dev --host 0.0.0.0
+		exit $?
 	fi
 
 	sleep 1


### PR DESCRIPTION
## Summary
- Add a dedicated cron weekly page with server-backed day/time fields and stale-request guards
- Track hidden cron jobs in SQLite, prune stale hidden rows, and add a settings reset action
- Improve cron parsing and history import for real-world nicknames, named days, and requested-week log inference
- Clean up dev and CI run paths so smoke tests and cleanup behave correctly

## Testing
- `cd frontend && bun run build`
- `go test ./internal/collectors ./internal/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cron expression nicknames (`@hourly`, `@yearly`, `@monthly`, etc.)
  * Enhanced cron scheduling UI with timezone display and improved time formatting
  * Cron expressions now support named weekdays and months (e.g., `mon`, `jan`)

* **Bug Fixes**
  * Fixed stale hidden job entries persisting after cron definitions change
  * Improved year inference when parsing cron log timestamps for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->