### PR TITLE
fix: codebase analysis findings 2026-05-02

### DIFF
--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -137,6 +137,9 @@ func (d *DockerCollector) GetContainerStats(containerID string) (*ContainerStats
 	if err != nil {
 		return nil, fmt.Errorf("read stats body: %w", err)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("docker stats %s: unexpected status %d", containerID, resp.StatusCode)
+	}
 
 	var raw struct {
 		Name     string `json:"name"`

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -66,6 +66,14 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 	}
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read containers body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("docker list: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
 	var raw []struct {
 		Id      string            `json:"Id"`
 		Names   []string          `json:"Names"`
@@ -82,7 +90,7 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 		} `json:"Ports"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("decode containers: %w", err)
 	}
 

--- a/internal/collectors/docker_test.go
+++ b/internal/collectors/docker_test.go
@@ -87,6 +87,42 @@ func TestGetAllStatsCollectsRunningContainersInParallel(t *testing.T) {
 	}
 }
 
+func TestListContainersReturnsErrorOnHTTPFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]string{"message": "boom"}); err != nil {
+			t.Fatalf("encode error payload: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	addr := strings.TrimPrefix(server.URL, "http://")
+	collector := &DockerCollector{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "tcp", addr)
+				},
+			},
+			Timeout: time.Second,
+		},
+	}
+
+	_, err := collector.ListContainers()
+	if err == nil {
+		t.Fatal("expected HTTP failure to return error")
+	}
+	if !strings.Contains(err.Error(), "500") || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected error to include status and body, got: %v", err)
+	}
+}
+
 func TestGetContainerStatsReturnsErrorOnHTTPFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/collectors/docker_test.go
+++ b/internal/collectors/docker_test.go
@@ -86,3 +86,35 @@ func TestGetAllStatsCollectsRunningContainersInParallel(t *testing.T) {
 		t.Fatalf("expected parallel collection under 300ms, got %s", elapsed)
 	}
 }
+
+func TestGetContainerStatsReturnsErrorOnHTTPFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/missing/stats", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		if err := json.NewEncoder(w).Encode(map[string]string{"message": "container not found"}); err != nil {
+			t.Fatalf("encode error payload: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	addr := strings.TrimPrefix(server.URL, "http://")
+	collector := &DockerCollector{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "tcp", addr)
+				},
+			},
+			Timeout: time.Second,
+		},
+	}
+
+	if _, err := collector.GetContainerStats("missing"); err == nil {
+		t.Fatal("expected HTTP failure to return error")
+	}
+}

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -112,7 +112,7 @@ func (f *Fail2BanCollector) getJailStatus(name string) (*JailStatus, error) {
 	return jail, nil
 }
 
-var banLogPattern = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)\s+fail2ban\.\w+\s+\[\d+\]:\s+\w+\s+\[(\w+)\]\s+(Ban|Unban)\s+(\S+)`)
+var banLogPattern = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)\s+fail2ban\.\w+\s+\[\d+\]:\s+\w+\s+\[([\w.-]+)\]\s+(Ban|Unban)\s+(\S+)`)
 
 func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 	logFile := filepath.Join(f.logPath, "fail2ban.log")
@@ -148,6 +148,10 @@ func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 			Action:    strings.ToLower(matches[3]),
 			IP:        matches[4],
 		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan fail2ban log: %w", err)
 	}
 
 	// Return last N events

--- a/internal/collectors/fail2ban_test.go
+++ b/internal/collectors/fail2ban_test.go
@@ -42,3 +42,28 @@ func TestGetRecentBansParsesCommaMilliseconds(t *testing.T) {
 		t.Fatalf("expected IP 1.2.3.4, got %q", events[0].IP)
 	}
 }
+
+func TestGetRecentBansParsesHyphenatedJailNames(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	logFile := filepath.Join(logDir, "fail2ban.log")
+	line := "2026-04-20 12:34:56,789 fail2ban.actions [1234]: NOTICE [sshd-ddos] Ban 1.2.3.4\n"
+	if err := os.WriteFile(logFile, []byte(line), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	collector := NewFail2BanCollector(logDir)
+	events, err := collector.GetRecentBans(10)
+	if err != nil {
+		t.Fatalf("GetRecentBans: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 ban event, got %d", len(events))
+	}
+
+	if events[0].Jail != "sshd-ddos" {
+		t.Fatalf("expected jail sshd-ddos, got %q", events[0].Jail)
+	}
+}

--- a/internal/collectors/logs.go
+++ b/internal/collectors/logs.go
@@ -89,6 +89,9 @@ func readLogFile(path string, unitName string, priorityFilter int) ([]LogEntry, 
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 
 	// Take last 500 lines
 	if len(lines) > 500 {
@@ -225,4 +228,3 @@ func priorityLabel(p int) string {
 		return "unknown"
 	}
 }
-

--- a/internal/collectors/logs_test.go
+++ b/internal/collectors/logs_test.go
@@ -1,0 +1,24 @@
+package collectors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadLogFileReturnsScannerErrors(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	logFile := filepath.Join(logDir, "syslog")
+	longLine := "Apr  1 18:30:00 host app[123]: " + strings.Repeat("x", 1024*1024+1) + "\n"
+	if err := os.WriteFile(logFile, []byte(longLine), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	_, err := readLogFile(logFile, "syslog", -1)
+	if err == nil {
+		t.Fatal("expected scanner error for oversized log line")
+	}
+}


### PR DESCRIPTION
Closes #20

## Summary
- Corretta la validazione delle risposte Docker stats: ora gli status HTTP non `200` tornano errore invece di metriche vuote.
- Corretta la lettura dei log Fail2Ban: i nomi jail con `-` o `.` vengono parse correttamente e gli errori di scan non vengono piu ignorati.
- Corretta la lettura dei log file generici: `scanner.Err()` ora viene propagato, con test di regressione per righe oversized.

---
*Generato automaticamente da Codebase Analyst*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Docker stats collection now validates HTTP response status codes and reports errors for failed requests
  * Added error reporting for log file scanning failures in fail2ban and logs collectors
  * Extended fail2ban support to handle hyphenated jail names

* **Tests**
  * Added test coverage for HTTP request failures, log scanning errors, and hyphenated jail name parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->