### PR TITLE
fix: codebase analysis findings 2026-05-09

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -16,7 +16,33 @@ var (
 	ErrInvalidCredentials = errors.New("invalid email or password")
 	ErrSessionExpired     = errors.New("session expired")
 	ErrSessionNotFound    = errors.New("session not found")
+	ErrPasswordTooLong    = errors.New("password exceeds 72 bytes")
 )
+
+// bcrypt hashes only the first 72 bytes of input; longer passwords are
+// silently truncated, hiding the fact that the rest is unchecked.
+const bcryptMaxPasswordBytes = 72
+
+// dummyBcryptHash is compared against on user-not-found login attempts so
+// timing matches the user-found path and prevents email enumeration.
+var dummyBcryptHash = mustGenerateDummyHash()
+
+func mustGenerateDummyHash() []byte {
+	h, err := bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), bcrypt.DefaultCost)
+	if err != nil {
+		panic(fmt.Sprintf("auth: pre-compute dummy hash: %v", err))
+	}
+	return h
+}
+
+// maskSessionID returns a short, log-safe identifier for a session token. The
+// full token is the bearer credential and must never appear in logs.
+func maskSessionID(sid string) string {
+	if len(sid) <= 8 {
+		return "***"
+	}
+	return sid[:8] + "..."
+}
 
 type User struct {
 	ID    int64  `json:"id"`
@@ -45,6 +71,9 @@ func (s *Service) Login(email, password string) (string, error) {
 		Scan(&user.ID, &user.PasswordHash)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// Burn one bcrypt comparison so timing matches the found-user path
+			// and the response cannot be used to enumerate registered emails.
+			_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 			return "", ErrInvalidCredentials
 		}
 		return "", fmt.Errorf("query user: %w", err)
@@ -93,7 +122,7 @@ func (s *Service) ValidateSession(sid string) (*User, error) {
 	}
 	if time.Now().UTC().After(expires) {
 		if _, err := s.db.Exec("DELETE FROM sessions WHERE id = ?", sid); err != nil {
-			log.Printf("failed to delete expired session %s: %v", sid, err)
+			log.Printf("failed to delete expired session %s: %v", maskSessionID(sid), err)
 		}
 		return nil, ErrSessionExpired
 	}
@@ -107,6 +136,9 @@ func (s *Service) Logout(sid string) error {
 }
 
 func (s *Service) CreateUser(email, password string) error {
+	if len([]byte(password)) > bcryptMaxPasswordBytes {
+		return ErrPasswordTooLong
+	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LiukScot/dashboard/internal/db"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "auth.sqlite")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := db.RunMigrations(database); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	return NewService(database, 3600)
+}
+
+func TestLoginSuccessReturnsSession(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	if err := svc.CreateUser("alice@example.com", "correct horse"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	sid, err := svc.Login("alice@example.com", "correct horse")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if len(sid) < 32 {
+		t.Fatalf("session id looks too short: %q", sid)
+	}
+	user, err := svc.ValidateSession(sid)
+	if err != nil {
+		t.Fatalf("validate session: %v", err)
+	}
+	if user.Email != "alice@example.com" {
+		t.Fatalf("expected alice@example.com, got %q", user.Email)
+	}
+}
+
+func TestLoginRejectsWrongPassword(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	if err := svc.CreateUser("bob@example.com", "right"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := svc.Login("bob@example.com", "wrong"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("expected ErrInvalidCredentials, got %v", err)
+	}
+}
+
+func TestLoginRejectsUnknownEmail(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	// Burn-bcrypt timing path runs; only the error contract is asserted here.
+	if _, err := svc.Login("ghost@example.com", "anything"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("expected ErrInvalidCredentials, got %v", err)
+	}
+}
+
+func TestCreateUserRejectsLongPassword(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	long := strings.Repeat("p", bcryptMaxPasswordBytes+1)
+	if err := svc.CreateUser("eve@example.com", long); !errors.Is(err, ErrPasswordTooLong) {
+		t.Fatalf("expected ErrPasswordTooLong, got %v", err)
+	}
+}
+
+func TestValidateSessionUnknownReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	if _, err := svc.ValidateSession("nonexistent"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestMaskSessionIDDoesNotLeakFullToken(t *testing.T) {
+	t.Parallel()
+	full := "abcdef0123456789abcdef0123456789"
+	masked := maskSessionID(full)
+	if strings.Contains(masked, full) {
+		t.Fatalf("masked output %q contains full token", masked)
+	}
+	if !strings.HasPrefix(masked, "abcdef01") {
+		t.Fatalf("expected prefix retained, got %q", masked)
+	}
+}

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -710,7 +710,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 	}
 
 	if err := tx.Commit(); err != nil {
-		return imported, append(warnings, fmt.Sprintf("history commit: %v", err))
+		return 0, append(warnings, fmt.Sprintf("history commit: %v", err))
 	}
 	committed = true
 

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -382,20 +382,21 @@ func parseCronLine(raw string, source string, lineNo int) (CronJob, bool, string
 	return job, true, ""
 }
 
+var cronNicknames = map[string]string{
+	"@yearly":   "0 0 1 1 *",
+	"@annually": "0 0 1 1 *",
+	"@monthly":  "0 0 1 * *",
+	"@weekly":   "0 0 * * 0",
+	"@daily":    "0 0 * * *",
+	"@midnight": "0 0 * * *",
+	"@hourly":   "0 * * * *",
+}
+
 func normalizeScheduleFields(first string) ([]string, string) {
 	if !strings.HasPrefix(first, "@") {
 		return nil, ""
 	}
-	nicknames := map[string]string{
-		"@yearly":   "0 0 1 1 *",
-		"@annually": "0 0 1 1 *",
-		"@monthly":  "0 0 1 * *",
-		"@weekly":   "0 0 * * 0",
-		"@daily":    "0 0 * * *",
-		"@midnight": "0 0 * * *",
-		"@hourly":   "0 * * * *",
-	}
-	if expanded, ok := nicknames[strings.ToLower(first)]; ok {
+	if expanded, ok := cronNicknames[strings.ToLower(first)]; ok {
 		return strings.Fields(expanded), ""
 	}
 	return nil, fmt.Sprintf("unsupported cron nickname %q", first)
@@ -669,6 +670,17 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 	imported := 0
 	var warnings []string
 
+	tx, err := c.db.Begin()
+	if err != nil {
+		return 0, []string{fmt.Sprintf("history tx: %v", err)}
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
 	for _, logFile := range logFiles {
 		file, err := os.Open(logFile)
 		if err != nil {
@@ -687,7 +699,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 			if !exists {
 				continue
 			}
-			if err := c.insertHistory(job.Fingerprint, observedAt, "observed", logFile, scanner.Text()); err == nil {
+			if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", logFile, scanner.Text()); err == nil {
 				imported++
 			}
 		}
@@ -696,6 +708,11 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 		}
 		_ = file.Close()
 	}
+
+	if err := tx.Commit(); err != nil {
+		return imported, append(warnings, fmt.Sprintf("history commit: %v", err))
+	}
+	committed = true
 
 	return imported, warnings
 }
@@ -720,10 +737,25 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 	cmd := exec.Command("journalctl", args...)
 	output, err := cmd.Output()
 	if err != nil {
-		return 0, []string{fmt.Sprintf("journalctl: %v", err)}, true
+		// journalctl is present but errored (perms, no readable journal,
+		// etc.); signal the caller to fall back to syslog files instead of
+		// silently masking the failure as a successful empty journal.
+		return 0, []string{fmt.Sprintf("journalctl: %v", err)}, false
 	}
 
+	tx, err := c.db.Begin()
+	if err != nil {
+		return 0, []string{fmt.Sprintf("history tx: %v", err)}, true
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
 	imported := 0
+	var warnings []string
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
 		observedAt, user, command, ok := parseCronLogLine(scanner.Text(), end.Add(-time.Second))
@@ -734,15 +766,20 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 		if !exists {
 			continue
 		}
-		if err := c.insertHistory(job.Fingerprint, observedAt, "observed", "journalctl", scanner.Text()); err == nil {
+		if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", "journalctl", scanner.Text()); err == nil {
 			imported++
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return imported, []string{fmt.Sprintf("journalctl scan: %v", err)}, true
+		warnings = append(warnings, fmt.Sprintf("journalctl scan: %v", err))
 	}
 
-	return imported, nil, true
+	if err := tx.Commit(); err != nil {
+		return imported, append(warnings, fmt.Sprintf("history commit: %v", err)), true
+	}
+	committed = true
+
+	return imported, warnings, true
 }
 
 func parseCronLogLine(line string, now time.Time) (time.Time, string, string, bool) {
@@ -784,6 +821,23 @@ func parseCronLogLine(line string, now time.Time) (time.Time, string, string, bo
 
 func (c *CronCollector) insertHistory(jobID string, observedAt time.Time, status string, source string, message string) error {
 	_, err := c.db.Exec(
+		`INSERT OR IGNORE INTO cron_run_history(job_id, scheduled_at, observed_at, status, source, message)
+		 VALUES(?, ?, ?, ?, ?, ?)`,
+		jobID,
+		observedAt.Truncate(time.Minute).Format(time.RFC3339),
+		observedAt.Format(time.RFC3339),
+		status,
+		source,
+		message,
+	)
+	return err
+}
+
+// txInsertHistory is the transactional twin of insertHistory; importers batch
+// thousands of inserts per call, so a single Begin/Commit beats the per-row
+// round trips against the SetMaxOpenConns(1) sqlite pool.
+func txInsertHistory(tx *sql.Tx, jobID string, observedAt time.Time, status string, source string, message string) error {
+	_, err := tx.Exec(
 		`INSERT OR IGNORE INTO cron_run_history(job_id, scheduled_at, observed_at, status, source, message)
 		 VALUES(?, ?, ?, ?, ?, ?)`,
 		jobID,

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -699,7 +699,9 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 			if !exists {
 				continue
 			}
-			if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", logFile, scanner.Text()); err == nil {
+			if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", logFile, scanner.Text()); err != nil {
+				warnings = append(warnings, fmt.Sprintf("insert history %s at %s from %s: %v (line: %q)", job.Fingerprint, observedAt.Format(time.RFC3339), logFile, err, scanner.Text()))
+			} else {
 				imported++
 			}
 		}
@@ -766,7 +768,9 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 		if !exists {
 			continue
 		}
-		if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", "journalctl", scanner.Text()); err == nil {
+		if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", "journalctl", scanner.Text()); err != nil {
+			warnings = append(warnings, fmt.Sprintf("insert history %s at %s from journalctl: %v (line: %q)", job.Fingerprint, observedAt.Format(time.RFC3339), err, scanner.Text()))
+		} else {
 			imported++
 		}
 	}
@@ -775,7 +779,7 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 	}
 
 	if err := tx.Commit(); err != nil {
-		return imported, append(warnings, fmt.Sprintf("history commit: %v", err)), true
+		return 0, append(warnings, fmt.Sprintf("history commit: %v", err)), true
 	}
 	committed = true
 

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -178,8 +178,15 @@ func (d *DockerCollector) GetContainerStats(containerID string) (*ContainerStats
 		return nil, fmt.Errorf("decode stats: %w", err)
 	}
 
-	cpuDelta := float64(raw.CPUStats.CPUUsage.TotalUsage - raw.PreCPUStats.CPUUsage.TotalUsage)
-	systemDelta := float64(raw.CPUStats.SystemCPUUsage - raw.PreCPUStats.SystemCPUUsage)
+	// Guard uint64 subtraction; counters can drop on container restart or
+	// stats reset, and wrap-around would surface as nonsense CPU%.
+	var cpuDelta, systemDelta float64
+	if raw.CPUStats.CPUUsage.TotalUsage >= raw.PreCPUStats.CPUUsage.TotalUsage {
+		cpuDelta = float64(raw.CPUStats.CPUUsage.TotalUsage - raw.PreCPUStats.CPUUsage.TotalUsage)
+	}
+	if raw.CPUStats.SystemCPUUsage >= raw.PreCPUStats.SystemCPUUsage {
+		systemDelta = float64(raw.CPUStats.SystemCPUUsage - raw.PreCPUStats.SystemCPUUsage)
+	}
 	cpuPercent := 0.0
 	if systemDelta > 0 && cpuDelta > 0 {
 		cpuPercent = (cpuDelta / systemDelta) * float64(raw.CPUStats.OnlineCPUs) * 100.0

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -127,6 +127,9 @@ func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 
 	var events []BanEvent
 	scanner := bufio.NewScanner(file)
+	// Default 64KiB token cap aborts the whole scan on a single long line;
+	// fail2ban traceback dumps can exceed it. Match logs.go.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	for scanner.Scan() {
 		matches := banLogPattern.FindStringSubmatch(scanner.Text())

--- a/internal/collectors/logs.go
+++ b/internal/collectors/logs.go
@@ -129,7 +129,14 @@ func parseSyslogLine(line string, unitName string) *LogEntry {
 		tsStr := line[:15]
 		t, err := time.Parse("Jan  2 15:04:05", tsStr)
 		if err == nil {
-			t = t.AddDate(time.Now().Year(), 0, 0)
+			now := time.Now()
+			t = time.Date(now.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, now.Location())
+			// Late-Dec lines parsed in early Jan would be tagged with the
+			// current year and surface as "future" entries; roll the year
+			// back when the parsed timestamp is more than a day ahead.
+			if t.After(now.Add(24 * time.Hour)) {
+				t = t.AddDate(-1, 0, 0)
+			}
 			ts = strconv.FormatInt(t.UnixMicro(), 10)
 			rest = strings.TrimSpace(line[15:])
 		}
@@ -141,8 +148,10 @@ func parseSyslogLine(line string, unitName string) *LogEntry {
 			ts = line[:25]
 			rest = strings.TrimSpace(line[25:])
 		} else {
-			ts = strconv.FormatInt(time.Now().UnixMicro(), 10)
-			rest = line
+			// Unparseable header — drop the line. Synthesizing time.Now()
+			// as a fallback would surface unparseable old log lines as
+			// "newest entries" once the desc sort runs.
+			return nil
 		}
 	}
 

--- a/internal/collectors/system.go
+++ b/internal/collectors/system.go
@@ -110,6 +110,9 @@ func (c *SystemCollector) CollectNetwork() ([]NetworkMetrics, error) {
 	var metrics []NetworkMetrics
 
 	lines := strings.Split(string(data), "\n")
+	if len(lines) < 3 {
+		return metrics, nil
+	}
 	for _, line := range lines[2:] {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -244,13 +247,18 @@ func (c *SystemCollector) readMemory(m *SystemMetrics) error {
 
 	m.MemTotal = values["MemTotal"]
 	memAvailable := values["MemAvailable"]
-	m.MemUsed = m.MemTotal - memAvailable
+	if m.MemTotal >= memAvailable {
+		m.MemUsed = m.MemTotal - memAvailable
+	}
 	if m.MemTotal > 0 {
 		m.MemPercent = 100.0 * float64(m.MemUsed) / float64(m.MemTotal)
 	}
 
 	m.SwapTotal = values["SwapTotal"]
-	m.SwapUsed = m.SwapTotal - values["SwapFree"]
+	swapFree := values["SwapFree"]
+	if m.SwapTotal >= swapFree {
+		m.SwapUsed = m.SwapTotal - swapFree
+	}
 	return nil
 }
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -41,6 +41,8 @@ var migrations = []string{
 		job_id    TEXT PRIMARY KEY,
 		hidden_at TEXT NOT NULL DEFAULT (datetime('now'))
 	)`,
+	`CREATE INDEX IF NOT EXISTS idx_cron_run_history_scheduled_at
+		ON cron_run_history(scheduled_at)`,
 }
 
-const SchemaVersion = 3
+const SchemaVersion = 4

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,7 +99,28 @@ func (s *Server) Start() error {
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 	log.Printf("dashboard listening on %s", addr)
 
-	return http.ListenAndServe(addr, s.corsMiddleware(s.mux))
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.securityHeaders(s.corsMiddleware(s.mux)),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      0, // 0 because /ws upgrades to a long-lived stream
+		IdleTimeout:       120 * time.Second,
+	}
+	return srv.ListenAndServe()
+}
+
+// securityHeaders sets baseline response headers that harden the SPA + cookie
+// session against XSS-driven clickjacking and MIME sniffing. CSP is left out
+// because the SPA bundle still inlines styles via Tailwind; add when fixed.
+func (s *Server) securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		next.ServeHTTP(w, r)
+	})
 }
 
 // CORS middleware
@@ -402,8 +423,13 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	// Sanitize path to prevent directory traversal
 	cleaned := filepath.Clean("/" + r.URL.Path)
 	filePath := filepath.Join(publicDir, cleaned)
-	absPublic, _ := filepath.Abs(publicDir)
-	absFile, _ := filepath.Abs(filePath)
+	absPublic, errPub := filepath.Abs(publicDir)
+	absFile, errFile := filepath.Abs(filePath)
+	if errPub != nil || errFile != nil {
+		log.Printf("static abs path resolution failed: pub=%v file=%v", errPub, errFile)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 	if !strings.HasPrefix(absFile, absPublic+string(os.PathSeparator)) && absFile != absPublic {
 		http.NotFound(w, r)
 		return
@@ -437,5 +463,7 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("writeJSON encode error (status=%d): %v", status, err)
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,7 +104,7 @@ func (s *Server) Start() error {
 		Handler:           s.securityHeaders(s.corsMiddleware(s.mux)),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      0, // 0 because /ws upgrades to a long-lived stream
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
 	return srv.ListenAndServe()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -189,6 +189,97 @@ func TestRequestOriginAllowedAllowsSameHostOrigin(t *testing.T) {
 	}
 }
 
+func TestWithAuthRejectsMissingCookie(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "dashboard.sqlite")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := db.RunMigrations(database); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	srv := &Server{
+		cfg:     &config.Config{SessionTTL: 3600},
+		authSvc: auth.NewService(database, 3600),
+	}
+
+	called := false
+	handler := srv.withAuth(func(w http.ResponseWriter, r *http.Request) { called = true })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/overview", nil)
+	res := httptest.NewRecorder()
+	handler(res, req)
+
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+	if called {
+		t.Fatal("inner handler must not run when cookie is missing")
+	}
+}
+
+func TestWithAuthRejectsInvalidSession(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "dashboard.sqlite")
+	database, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := db.RunMigrations(database); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+
+	srv := &Server{
+		cfg:     &config.Config{SessionTTL: 3600},
+		authSvc: auth.NewService(database, 3600),
+	}
+
+	called := false
+	handler := srv.withAuth(func(w http.ResponseWriter, r *http.Request) { called = true })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/overview", nil)
+	req.AddCookie(&http.Cookie{Name: "DASHBOARD_SESSID", Value: "does-not-exist"})
+	res := httptest.NewRecorder()
+	handler(res, req)
+
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+	if called {
+		t.Fatal("inner handler must not run for invalid session")
+	}
+}
+
+func TestSecurityHeadersSet(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{cfg: &config.Config{}}
+	wrapped := srv.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	wrapped.ServeHTTP(res, req)
+
+	checks := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "no-referrer",
+	}
+	for header, want := range checks {
+		if got := res.Header().Get(header); got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+}
+
 func TestRequestOriginAllowedRejectsOtherOrigin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -63,6 +63,8 @@ func (h *Hub) Broadcast(data []byte) {
 	var failed []*connWithMu
 	for c := range h.clients {
 		c.mu.Lock()
+		// 10s write deadline so a stuck client doesn't pile up goroutines.
+		_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 		err := c.conn.WriteMessage(websocket.TextMessage, data)
 		c.mu.Unlock()
 		if err != nil {
@@ -100,6 +102,11 @@ func NewWSHandler(hub *Hub, authSvc *auth.Service, sysColl *collectors.SystemCol
 	}
 }
 
+// wsMaxMessageBytes caps inbound frame size to prevent a single client from
+// asking us to allocate arbitrarily large buffers (gorilla/websocket reads
+// the whole frame before returning).
+const wsMaxMessageBytes = 1 << 16
+
 func (ws *WSHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 	_, err := auth.ValidateSessionFromCookie(ws.authSvc, r)
 	if err != nil {
@@ -112,6 +119,8 @@ func (ws *WSHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 		log.Printf("ws upgrade error: %v", err)
 		return
 	}
+
+	conn.SetReadLimit(wsMaxMessageBytes)
 
 	c := ws.hub.Register(conn)
 	log.Printf("ws client connected (%d total)", ws.hub.ClientCount())


### PR DESCRIPTION
## Summary

High-confidence fixes from the weekly multi-pass codebase analysis (security,
bugs, performance, dependencies, tests).

### Security
- HTTP server timeouts + Slowloris mitigation; baseline security headers.
- WebSocket: cap inbound frame size, add write deadline so stuck clients
  cannot pile up goroutines.
- Stop swallowing `filepath.Abs` errors in the static-file traversal guard
  and surface `writeJSON` encode failures.
- Auth: reject passwords > 72 bytes (bcrypt silent truncation), run dummy
  bcrypt on user-not-found path to remove the email-enumeration timing
  oracle, and mask session IDs in logs (full sid was the bearer credential).

### Bugs
- `cron`: `importJournalHistory` was returning `usedJournal=true` when
  `journalctl` errored, blocking the syslog/cron-file fallback; now returns
  false on Output() error.
- `docker`: guard uint64 wrap on CPU delta when stats counters reset.
- `system`: guard `/proc/net/dev` short read and MemUsed/SwapUsed underflow.
- `logs`: drop lines with unparseable timestamps instead of stamping them
  with `time.Now()` (they had been surfacing as the newest entries); fix
  late-Dec / early-Jan year rollback in syslog parser.
- `fail2ban`: raise scanner buffer to 1 MiB to avoid full-scan abort on
  long lines.

### Performance
- Add `idx_cron_run_history_scheduled_at` for the range scan that runs on
  every `/api/v1/cron/week` (SchemaVersion → 4).
- Batch cron history inserts inside a single sqlite tx instead of N round
  trips against the `SetMaxOpenConns(1)` pool.
- Promote cron `nicknames` map to a package-level var (was reallocated per
  call).

### Tests
- New `internal/auth/auth_test.go`: Login success / wrong password /
  unknown email (timing path), CreateUser >72-byte rejection,
  ValidateSession unknown, session-id mask.
- New `withAuth` (missing cookie, invalid session) and security-headers
  middleware tests in `internal/server/server_test.go`.

## Findings deferred (need design discussion, not in this PR)

- WS half-open client cleanup (requires server-side ping/pong loop).
- Origin allowlist same-Host fallback (kept; existing test asserts it,
  removing it would break some deployments).
- `COOKIE_SECURE=false` default and 30-day session TTL (deployment policy).
- Login rate limiting / lockout, CSP, HSTS.
- Frontend test infra (vitest / Playwright) — none in repo today.
- Vite / @sveltejs/kit / postcss CVE-driven upgrades and Dockerfile
  digest pinning.
- Frontend dead code (`stores/metrics.ts`, `parseHeight` in TimeChart),
  `formatBytes` duplication, hardcoded hex in Svelte components.
- N+1 hidden-job delete in `pruneStaleHidden`, full-file syslog load,
  `O(N²)` container-stats lookup in `ContainerTable`.

---
*Generated automatically by Codebase Analyst — 2026-05-09*