### PR TITLE
ci(pr-review): skip Dependabot PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,7 +23,13 @@ concurrency:
 jobs:
   review:
     # Skip forked PRs: secrets.CLAUDE_CODE_OAUTH_TOKEN non e' esposto su pull_request da fork.
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip Dependabot PRs: girano con Dependabot secrets (store separato), CLAUDE_CODE_OAUTH_TOKEN
+    # non e' disponibile -> l'action crasha. Bump deterministici di versione: il test suite e
+    # security.yml (npm-audit + dependency-review) sono il gate giusto, non la review LLM.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Skip the Claude review job for PRs authored by `dependabot[bot]`. Dependabot PRs run with Dependabot secrets — a separate restricted store where `CLAUDE_CODE_OAUTH_TOKEN` is not available — so the action crashes at token init.

The right gate for version-bump breakage is the test suite + dependency-scanning workflows, not LLM review.

## Note

The `review` check on this PR will fail — that is GitHub's expected behavior when modifying the review workflow itself ("workflow file must exist and have identical content to the version on the repository's default branch"). Future Dependabot PRs after merge will skip cleanly.

## Test plan

- [ ] After merge, next Dependabot PR shows `review` job skipped, not failed.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>