### PR TITLE
feat: error visibility, responsive layout, WS resilience, healthz

### DIFF
--- a/frontend/src/components/Toast.svelte
+++ b/frontend/src/components/Toast.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { getToasts, dismissToast, type Toast } from '$lib/stores/toast.svelte';
+
+	const toasts = $derived<Toast[]>(getToasts());
+
+	const kindClasses: Record<Toast['kind'], string> = {
+		error: 'border-danger/40 bg-danger/15 text-danger',
+		success: 'border-success/40 bg-success/15 text-success',
+		info: 'border-info/40 bg-info/15 text-info'
+	};
+</script>
+
+<div
+	class="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2"
+	role="region"
+	aria-label="Notifications"
+	aria-live="polite"
+>
+	{#each toasts as toast (toast.id)}
+		<div
+			class="pointer-events-auto flex items-start gap-3 rounded-lg border bg-bg-card px-4 py-3 text-sm shadow-lg {kindClasses[toast.kind]}"
+			role="status"
+		>
+			<span class="flex-1 break-words">{toast.message}</span>
+			<button
+				type="button"
+				class="text-current opacity-70 transition hover:opacity-100 cursor-pointer"
+				onclick={() => dismissToast(toast.id)}
+				aria-label="Dismiss notification"
+			>
+				✕
+			</button>
+		</div>
+	{/each}
+</div>

--- a/frontend/src/components/Toast.svelte
+++ b/frontend/src/components/Toast.svelte
@@ -2,6 +2,8 @@
 	import { getToasts, dismissToast, type Toast } from '$lib/stores/toast.svelte';
 
 	const toasts = $derived<Toast[]>(getToasts());
+	const polite = $derived(toasts.filter((t) => t.kind !== 'error'));
+	const assertive = $derived(toasts.filter((t) => t.kind === 'error'));
 
 	const kindClasses: Record<Toast['kind'], string> = {
 		error: 'border-danger/40 bg-danger/15 text-danger',
@@ -10,26 +12,44 @@
 	};
 </script>
 
-<div
-	class="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2"
-	role="region"
-	aria-label="Notifications"
-	aria-live="polite"
->
-	{#each toasts as toast (toast.id)}
-		<div
-			class="pointer-events-auto flex items-start gap-3 rounded-lg border bg-bg-card px-4 py-3 text-sm shadow-lg {kindClasses[toast.kind]}"
-			role="status"
-		>
-			<span class="flex-1 break-words">{toast.message}</span>
-			<button
-				type="button"
-				class="text-current opacity-70 transition hover:opacity-100 cursor-pointer"
-				onclick={() => dismissToast(toast.id)}
-				aria-label="Dismiss notification"
+<!--
+	Two stacked regions so screen readers handle errors interrupt-style
+	while non-error toasts queue politely. Single live-region role on the
+	region; toast items themselves carry no role to avoid double-announce.
+-->
+<div class="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2">
+	<div role="region" aria-label="Errors" aria-live="assertive" class="flex flex-col gap-2">
+		{#each assertive as toast (toast.id)}
+			<div
+				class="pointer-events-auto flex items-start gap-3 rounded-lg border bg-bg-card px-4 py-3 text-sm shadow-lg {kindClasses[toast.kind]}"
 			>
-				✕
-			</button>
-		</div>
-	{/each}
+				<span class="flex-1 break-words">{toast.message}</span>
+				<button
+					type="button"
+					class="text-current opacity-70 transition hover:opacity-100 cursor-pointer"
+					onclick={() => dismissToast(toast.id)}
+					aria-label="Dismiss notification"
+				>
+					✕
+				</button>
+			</div>
+		{/each}
+	</div>
+	<div role="region" aria-label="Notifications" aria-live="polite" class="flex flex-col gap-2">
+		{#each polite as toast (toast.id)}
+			<div
+				class="pointer-events-auto flex items-start gap-3 rounded-lg border bg-bg-card px-4 py-3 text-sm shadow-lg {kindClasses[toast.kind]}"
+			>
+				<span class="flex-1 break-words">{toast.message}</span>
+				<button
+					type="button"
+					class="text-current opacity-70 transition hover:opacity-100 cursor-pointer"
+					onclick={() => dismissToast(toast.id)}
+					aria-label="Dismiss notification"
+				>
+					✕
+				</button>
+			</div>
+		{/each}
+	</div>
 </div>

--- a/frontend/src/lib/stores/toast.svelte.ts
+++ b/frontend/src/lib/stores/toast.svelte.ts
@@ -7,6 +7,7 @@ export interface Toast {
 }
 
 let _toasts = $state<Toast[]>([]);
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
 let nextId = 1;
 
 const DEFAULT_DURATION_MS = 5000;
@@ -19,12 +20,18 @@ export function pushToast(kind: ToastKind, message: string, durationMs = DEFAULT
 	const id = nextId++;
 	_toasts = [..._toasts, { id, kind, message }];
 	if (durationMs > 0) {
-		setTimeout(() => dismissToast(id), durationMs);
+		const timer = setTimeout(() => dismissToast(id), durationMs);
+		timers.set(id, timer);
 	}
 	return id;
 }
 
 export function dismissToast(id: number): void {
+	const timer = timers.get(id);
+	if (timer !== undefined) {
+		clearTimeout(timer);
+		timers.delete(id);
+	}
 	_toasts = _toasts.filter((t) => t.id !== id);
 }
 

--- a/frontend/src/lib/stores/toast.svelte.ts
+++ b/frontend/src/lib/stores/toast.svelte.ts
@@ -1,0 +1,34 @@
+export type ToastKind = 'error' | 'success' | 'info';
+
+export interface Toast {
+	id: number;
+	kind: ToastKind;
+	message: string;
+}
+
+let _toasts = $state<Toast[]>([]);
+let nextId = 1;
+
+const DEFAULT_DURATION_MS = 5000;
+
+export function getToasts(): Toast[] {
+	return _toasts;
+}
+
+export function pushToast(kind: ToastKind, message: string, durationMs = DEFAULT_DURATION_MS): number {
+	const id = nextId++;
+	_toasts = [..._toasts, { id, kind, message }];
+	if (durationMs > 0) {
+		setTimeout(() => dismissToast(id), durationMs);
+	}
+	return id;
+}
+
+export function dismissToast(id: number): void {
+	_toasts = _toasts.filter((t) => t.id !== id);
+}
+
+export function toastError(err: unknown, fallback: string): void {
+	const message = err instanceof Error ? err.message : fallback;
+	pushToast('error', message);
+}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -58,8 +58,10 @@ function tryConnect() {
 			for (const listener of listeners) {
 				listener(msg);
 			}
-		} catch {
-			// ignore parse errors: server should never send invalid JSON
+		} catch (err) {
+			// Server protocol violation. Log so deploy schema drift / partial
+			// frames don't surface as silent stale charts.
+			console.error('ws: failed to parse metrics frame', err, event.data);
 		}
 	};
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -7,15 +7,36 @@ export interface MetricsMessage {
 	docker?: ContainerStats[];
 }
 
+export type WsState = 'connecting' | 'connected' | 'disconnected';
+
 type Listener = (msg: MetricsMessage) => void;
+type StateListener = (state: WsState) => void;
 
 let socket: WebSocket | null = null;
-let listeners: Set<Listener> = new Set();
+const listeners: Set<Listener> = new Set();
+const stateListeners: Set<StateListener> = new Set();
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let attempt = 0;
+let currentState: WsState = 'disconnected';
+
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
 
 function getWsUrl(): string {
 	const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
 	return `${proto}//${location.host}/ws`;
+}
+
+function setState(next: WsState): void {
+	if (currentState === next) return;
+	currentState = next;
+	for (const l of stateListeners) l(next);
+}
+
+function backoffDelay(): number {
+	// 1s, 2s, 4s, 8s, 16s, 30s (cap)
+	const exp = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+	return exp;
 }
 
 function tryConnect() {
@@ -23,7 +44,13 @@ function tryConnect() {
 		return;
 	}
 
+	setState('connecting');
 	socket = new WebSocket(getWsUrl());
+
+	socket.onopen = () => {
+		attempt = 0;
+		setState('connected');
+	};
 
 	socket.onmessage = (event) => {
 		try {
@@ -32,15 +59,18 @@ function tryConnect() {
 				listener(msg);
 			}
 		} catch {
-			// ignore parse errors
+			// ignore parse errors: server should never send invalid JSON
 		}
 	};
 
 	socket.onclose = () => {
 		socket = null;
-		if (listeners.size > 0) {
-			reconnectTimer = setTimeout(tryConnect, 3000);
-		}
+		setState('disconnected');
+		if (listeners.size === 0) return;
+
+		const delay = backoffDelay();
+		attempt += 1;
+		reconnectTimer = setTimeout(tryConnect, delay);
 	};
 
 	socket.onerror = () => {
@@ -56,8 +86,21 @@ export function subscribe(listener: Listener): () => void {
 		listeners.delete(listener);
 		if (listeners.size === 0) {
 			if (reconnectTimer) clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+			attempt = 0;
 			socket?.close();
 			socket = null;
+			setState('disconnected');
 		}
 	};
+}
+
+export function subscribeState(listener: StateListener): () => void {
+	stateListeners.add(listener);
+	listener(currentState);
+	return () => stateListeners.delete(listener);
+}
+
+export function getState(): WsState {
+	return currentState;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -17,6 +17,22 @@
 	let mobileNavOpen = $state(false);
 	let wsState = $state<WsState>('disconnected');
 	let unsubscribeWs: (() => void) | null = null;
+	let hamburgerBtn: HTMLButtonElement | null = $state(null);
+	let mobileNav: HTMLElement | null = $state(null);
+
+	$effect(() => {
+		if (!mobileNavOpen) return;
+		// Move focus into the drawer so keyboard / screen-reader users can
+		// navigate it without first tabbing through the rest of the page.
+		const target = mobileNav?.querySelector<HTMLElement>('a, button');
+		target?.focus();
+	});
+
+	function handleNavKey(e: KeyboardEvent) {
+		if (e.key === 'Escape' && mobileNavOpen) {
+			closeMobileNav();
+		}
+	}
 
 	onMount(async () => {
 		const session = await api.session();
@@ -36,6 +52,7 @@
 
 	function closeMobileNav() {
 		mobileNavOpen = false;
+		hamburgerBtn?.focus();
 	}
 
 	const navItems = [
@@ -56,6 +73,8 @@
 		disconnected: 'bg-danger'
 	};
 </script>
+
+<svelte:window onkeydown={handleNavKey} />
 
 {#if loading}
 	<div class="h-screen flex items-center justify-center">
@@ -127,6 +146,9 @@
 			></button>
 		{/if}
 		<nav
+			bind:this={mobileNav}
+			id="primary-nav"
+			aria-label="Primary"
 			class="fixed inset-y-0 left-0 z-40 w-56 bg-bg-card border-r border-border flex flex-col shrink-0 transform transition-transform duration-200
 				md:static md:translate-x-0
 				{mobileNavOpen ? 'translate-x-0' : '-translate-x-full'}"
@@ -174,10 +196,12 @@
 		<main class="flex-1 overflow-y-auto">
 			<header class="md:hidden sticky top-0 z-20 flex items-center justify-between gap-3 border-b border-border bg-bg-card px-4 py-3">
 				<button
+					bind:this={hamburgerBtn}
 					type="button"
 					class="text-text hover:text-accent cursor-pointer"
 					aria-label="Open navigation"
 					aria-expanded={mobileNavOpen}
+					aria-controls="primary-nav"
 					onclick={() => (mobileNavOpen = true)}
 				>
 					<svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -101,7 +101,9 @@
 			}}
 		>
 			<h1 class="text-xl font-semibold mb-6 text-center">Dashboard</h1>
+			<label for="login-email" class="sr-only">Email</label>
 			<input
+				id="login-email"
 				name="email"
 				type="email"
 				placeholder="Email"
@@ -110,7 +112,9 @@
 				aria-invalid={loginError ? 'true' : undefined}
 				class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-3 text-sm focus:outline-none focus:border-accent transition-colors"
 			/>
+			<label for="login-password" class="sr-only">Password</label>
 			<input
+				id="login-password"
 				name="password"
 				type="password"
 				placeholder="Password"

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/state';
-	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { onMount, onDestroy } from 'svelte';
 	import { api } from '$lib/api';
+	import Toast from '../components/Toast.svelte';
+	import { subscribeState, type WsState } from '$lib/ws';
 
 	interface Props {
 		children: import('svelte').Snippet;
@@ -13,16 +14,28 @@
 	let user = $state<{ id: number; email: string } | null>(null);
 	let loading = $state(true);
 	let loginError = $state('');
+	let mobileNavOpen = $state(false);
+	let wsState = $state<WsState>('disconnected');
+	let unsubscribeWs: (() => void) | null = null;
 
 	onMount(async () => {
 		const session = await api.session();
 		user = session.authenticated ? (session.user ?? null) : null;
 		loading = false;
+		unsubscribeWs = subscribeState((s) => (wsState = s));
+	});
+
+	onDestroy(() => {
+		unsubscribeWs?.();
 	});
 
 	async function logout() {
 		await api.logout();
 		user = null;
+	}
+
+	function closeMobileNav() {
+		mobileNavOpen = false;
 	}
 
 	const navItems = [
@@ -31,6 +44,17 @@
 		{ href: '/cron', label: 'Cron', icon: '◷' },
 		{ href: '/settings', label: 'Settings', icon: '⚙' }
 	];
+
+	const wsLabels: Record<WsState, string> = {
+		connecting: 'Connecting…',
+		connected: 'Live',
+		disconnected: 'Disconnected'
+	};
+	const wsDotClass: Record<WsState, string> = {
+		connecting: 'bg-warning animate-pulse',
+		connected: 'bg-success',
+		disconnected: 'bg-danger'
+	};
 </script>
 
 {#if loading}
@@ -39,45 +63,52 @@
 	</div>
 {:else if !user}
 	<!-- Login form -->
-	<div class="h-screen flex items-center justify-center">
+	<div class="h-screen flex items-center justify-center px-4">
 		<form
 			class="bg-bg-card border border-border rounded-xl p-8 w-full max-w-sm"
-				onsubmit={async (e) => {
-					e.preventDefault();
+			onsubmit={async (e) => {
+				e.preventDefault();
+				loginError = '';
+				const form = e.currentTarget;
+				const data = new FormData(form);
+				try {
+					await api.login(data.get('email') as string, data.get('password') as string);
+					const session = await api.session();
+					user = session.authenticated ? (session.user ?? null) : null;
 					loginError = '';
-					const form = e.currentTarget;
-					const data = new FormData(form);
-					try {
-						await api.login(data.get('email') as string, data.get('password') as string);
-						const session = await api.session();
-						user = session.authenticated ? (session.user ?? null) : null;
-						loginError = '';
-					} catch (err) {
-						loginError = err instanceof Error ? err.message : 'Sign in failed';
-					}
-				}}
-			>
+				} catch (err) {
+					loginError = err instanceof Error ? err.message : 'Sign in failed';
+				}
+			}}
+		>
 			<h1 class="text-xl font-semibold mb-6 text-center">Dashboard</h1>
 			<input
 				name="email"
 				type="email"
 				placeholder="Email"
+				autocomplete="email"
 				required
+				aria-invalid={loginError ? 'true' : undefined}
 				class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-3 text-sm focus:outline-none focus:border-accent transition-colors"
 			/>
-				<input
-					name="password"
-					type="password"
+			<input
+				name="password"
+				type="password"
 				placeholder="Password"
+				autocomplete="current-password"
 				required
-					class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-4 text-sm focus:outline-none focus:border-accent transition-colors"
-				/>
-				{#if loginError}
-					<p class="mb-4 text-sm text-danger">{loginError}</p>
-				{/if}
-				<button
-					type="submit"
-					class="w-full bg-accent text-bg font-medium rounded-lg py-2.5 text-sm hover:opacity-90 transition-opacity cursor-pointer"
+				aria-invalid={loginError ? 'true' : undefined}
+				aria-describedby={loginError ? 'login-error' : undefined}
+				class="w-full bg-bg border border-border rounded-lg px-4 py-2.5 mb-2 text-sm focus:outline-none focus:border-accent transition-colors"
+			/>
+			{#if loginError}
+				<p id="login-error" role="alert" class="mb-4 text-sm text-danger">{loginError}</p>
+			{:else}
+				<div class="mb-4"></div>
+			{/if}
+			<button
+				type="submit"
+				class="w-full bg-accent text-bg font-medium rounded-lg py-2.5 text-sm hover:opacity-90 transition-opacity cursor-pointer"
 			>
 				Sign in
 			</button>
@@ -86,16 +117,37 @@
 {:else}
 	<!-- App shell -->
 	<div class="flex h-screen">
-		<!-- Sidebar -->
-		<nav class="w-56 bg-bg-card border-r border-border flex flex-col shrink-0">
-			<div class="px-5 py-5 border-b border-border">
+		<!-- Sidebar (desktop static, mobile drawer) -->
+		{#if mobileNavOpen}
+			<button
+				type="button"
+				class="fixed inset-0 z-30 bg-black/50 md:hidden"
+				aria-label="Close navigation"
+				onclick={closeMobileNav}
+			></button>
+		{/if}
+		<nav
+			class="fixed inset-y-0 left-0 z-40 w-56 bg-bg-card border-r border-border flex flex-col shrink-0 transform transition-transform duration-200
+				md:static md:translate-x-0
+				{mobileNavOpen ? 'translate-x-0' : '-translate-x-full'}"
+		>
+			<div class="px-5 py-5 border-b border-border flex items-center justify-between">
 				<h1 class="text-sm font-semibold tracking-wide text-accent">DASHBOARD</h1>
+				<button
+					type="button"
+					class="md:hidden text-text-dim hover:text-text cursor-pointer"
+					aria-label="Close navigation"
+					onclick={closeMobileNav}
+				>
+					✕
+				</button>
 			</div>
 
 			<div class="flex-1 py-3">
 				{#each navItems as item}
 					<a
 						href={item.href}
+						onclick={closeMobileNav}
 						class="flex items-center gap-3 px-5 py-2.5 text-sm transition-colors
 							{page.url.pathname === item.href
 								? 'text-accent bg-accent-dim'
@@ -108,7 +160,7 @@
 			</div>
 
 			<div class="px-5 py-4 border-t border-border">
-				<div class="text-xs text-text-dim mb-2">{user.email}</div>
+				<div class="text-xs text-text-dim mb-2 break-all">{user.email}</div>
 				<button
 					onclick={logout}
 					class="text-xs text-text-dim hover:text-danger transition-colors cursor-pointer"
@@ -119,8 +171,41 @@
 		</nav>
 
 		<!-- Main content -->
-		<main class="flex-1 overflow-y-auto p-6">
-			{@render children()}
+		<main class="flex-1 overflow-y-auto">
+			<header class="md:hidden sticky top-0 z-20 flex items-center justify-between gap-3 border-b border-border bg-bg-card px-4 py-3">
+				<button
+					type="button"
+					class="text-text hover:text-accent cursor-pointer"
+					aria-label="Open navigation"
+					aria-expanded={mobileNavOpen}
+					onclick={() => (mobileNavOpen = true)}
+				>
+					<svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+						<path d="M3 6h18M3 12h18M3 18h18" />
+					</svg>
+				</button>
+				<h1 class="text-sm font-semibold tracking-wide text-accent">DASHBOARD</h1>
+				<span
+					class="flex items-center gap-1.5 text-xs text-text-dim"
+					title={wsLabels[wsState]}
+				>
+					<span class="h-2 w-2 rounded-full {wsDotClass[wsState]}" aria-hidden="true"></span>
+					<span class="sr-only">{wsLabels[wsState]}</span>
+				</span>
+			</header>
+			<div
+				class="absolute right-4 top-4 z-10 hidden items-center gap-2 rounded-full border border-border bg-bg-card px-3 py-1 text-xs text-text-dim md:flex"
+				title={wsLabels[wsState]}
+				aria-live="polite"
+			>
+				<span class="h-2 w-2 rounded-full {wsDotClass[wsState]}" aria-hidden="true"></span>
+				{wsLabels[wsState]}
+			</div>
+			<div class="p-4 md:p-6">
+				{@render children()}
+			</div>
 		</main>
 	</div>
 {/if}
+
+<Toast />

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 		type HistorySample
 	} from '$lib/api';
 	import { subscribe, type MetricsMessage } from '$lib/ws';
+	import { toastError } from '$lib/stores/toast.svelte';
 	import GaugeRing from '../components/GaugeRing.svelte';
 	import TimeChart from '../components/TimeChart.svelte';
 	import ContainerTable from '../components/ContainerTable.svelte';
@@ -19,6 +20,7 @@
 	let containers = $state<Container[]>([]);
 	let dockerStats = $state<ContainerStats[]>([]);
 	let dockerError = $state('');
+	let initialLoading = $state(true);
 	type LivePoint = { time: string; cpu: number; mem: number; disk: number; swap: number };
 	let liveHistory = $state<LivePoint[]>([]);
 	let netHistory = $state<{ time: string; rx: number; tx: number }[]>([]);
@@ -111,6 +113,7 @@
 		} catch (err) {
 			historySamples = [];
 			historyError = err instanceof Error ? err.message : 'Failed to load history';
+			toastError(err, 'Failed to load history');
 		} finally {
 			historyLoading = false;
 		}
@@ -136,33 +139,42 @@
 	}
 
 	onMount(async () => {
-		const [sys, hist, netSeed] = await Promise.all([
-			api.systemOverview(),
-			api.cpuHistory(),
-			api.systemHistory('1h').catch(() => [] as HistorySample[])
-		]);
-		system = sys;
-		liveHistory = hist.map((h) => ({
-			time: new Date(h.timestamp).toLocaleTimeString(),
-			cpu: h.cpuPercent,
-			mem: h.memPercent,
-			disk: h.diskPercent,
-			swap: h.swapTotal > 0 ? (h.swapUsed / h.swapTotal) * 100 : 0
-		}));
-		// Seed live network buffer from persisted history so chart isn't empty on reload.
-		netHistory = netSeed.slice(-60).map((s) => ({
-			time: new Date(s.timestamp * 1000).toLocaleTimeString(),
-			rx: s.netRxRate / 1024,
-			tx: s.netTxRate / 1024
-		}));
+		try {
+			const [sys, hist, netSeed] = await Promise.all([
+				api.systemOverview(),
+				api.cpuHistory(),
+				api.systemHistory('1h').catch((err) => {
+					// network history is non-critical: chart can render without seed
+					toastError(err, 'Failed to seed network history');
+					return [] as HistorySample[];
+				})
+			]);
+			system = sys;
+			liveHistory = hist.map((h) => ({
+				time: new Date(h.timestamp).toLocaleTimeString(),
+				cpu: h.cpuPercent,
+				mem: h.memPercent,
+				disk: h.diskPercent,
+				swap: h.swapTotal > 0 ? (h.swapUsed / h.swapTotal) * 100 : 0
+			}));
+			netHistory = netSeed.slice(-60).map((s) => ({
+				time: new Date(s.timestamp * 1000).toLocaleTimeString(),
+				rx: s.netRxRate / 1024,
+				tx: s.netTxRate / 1024
+			}));
+		} catch (err) {
+			toastError(err, 'Failed to load system overview');
+		} finally {
+			initialLoading = false;
+		}
 
 		try {
 			containers = await api.dockerContainers();
 			dockerError = '';
 		} catch (err) {
 			containers = [];
-
 			dockerError = err instanceof Error ? err.message : 'Failed to load containers';
+			toastError(err, 'Failed to load Docker containers');
 		}
 
 		// WebSocket for live updates
@@ -222,6 +234,11 @@
 </script>
 
 <div class="space-y-6">
+	{#if initialLoading}
+		<div class="flex items-center justify-center py-16">
+			<div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" role="status" aria-label="Loading overview"></div>
+		</div>
+	{:else}
 	<!-- Header -->
 	<div class="flex items-center justify-between">
 		<div>
@@ -335,4 +352,5 @@
 		{/if}
 		<ContainerTable {containers} stats={dockerStats} />
 	</div>
+	{/if}
 </div>

--- a/frontend/src/routes/security/+page.svelte
+++ b/frontend/src/routes/security/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api, type Fail2BanStatus, type BanEvent, type LogEntry } from '$lib/api';
+	import { toastError } from '$lib/stores/toast.svelte';
 
 	let f2bStatus = $state<Fail2BanStatus | null>(null);
 	let banEvents = $state<BanEvent[]>([]);
@@ -16,9 +17,18 @@
 
 	async function refresh() {
 		const [status, bans, logEntries] = await Promise.all([
-			api.fail2ban().catch(() => null),
-			api.fail2banBans().catch(() => []),
-			api.logs(logUnit, logPriority).catch(() => [])
+			api.fail2ban().catch((err) => {
+				toastError(err, 'Failed to load fail2ban status');
+				return null;
+			}),
+			api.fail2banBans().catch((err) => {
+				toastError(err, 'Failed to load ban events');
+				return [] as BanEvent[];
+			}),
+			api.logs(logUnit, logPriority).catch((err) => {
+				toastError(err, 'Failed to load logs');
+				return [] as LogEntry[];
+			})
 		]);
 		f2bStatus = status;
 		banEvents = bans;
@@ -26,7 +36,12 @@
 	}
 
 	async function filterLogs() {
-		logs = await api.logs(logUnit, logPriority).catch(() => []);
+		try {
+			logs = await api.logs(logUnit, logPriority);
+		} catch (err) {
+			logs = [];
+			toastError(err, 'Failed to filter logs');
+		}
 	}
 
 	function formatTimestamp(ts: string): string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	cronColl   *collectors.CronCollector
 	wsHandler  *WSHandler
 	mux        *http.ServeMux
+	startedAt  time.Time
 }
 
 func New(cfg *config.Config, authSvc *auth.Service,
@@ -52,6 +53,7 @@ func New(cfg *config.Config, authSvc *auth.Service,
 		cronColl:   cronColl,
 		wsHandler:  wsHandler,
 		mux:        http.NewServeMux(),
+		startedAt:  time.Now(),
 	}
 
 	s.routes()
@@ -84,6 +86,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/v1/cron/jobs/{fingerprint}/hide", s.withAuth(s.handleHideCronJob))
 	s.mux.HandleFunc("DELETE /api/v1/cron/hidden", s.withAuth(s.handleResetHiddenCronJobs))
 	s.mux.HandleFunc("GET /api/v1/cron/hidden/count", s.withAuth(s.handleHiddenCronJobCount))
+
+	// Health check (no auth: used by load balancers / external monitors)
+	s.mux.HandleFunc("GET /healthz", s.handleHealth)
 
 	// WebSocket
 	s.mux.HandleFunc("GET /ws", s.wsHandler.HandleUpgrade)
@@ -443,6 +448,15 @@ func (s *Server) handleHiddenCronJobCount(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int{"count": count})
+}
+
+// --- Health ---
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "ok",
+		"uptime": int64(time.Since(s.startedAt).Seconds()),
+	})
 }
 
 // --- Static file serving (SPA) ---

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -277,6 +278,34 @@ func TestSecurityHeadersSet(t *testing.T) {
 		if got := res.Header().Get(header); got != want {
 			t.Errorf("header %s = %q, want %q", header, got, want)
 		}
+	}
+}
+
+func TestHandleHealthReturnsStatusAndUptime(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{startedAt: time.Now().Add(-2 * time.Second)}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	res := httptest.NewRecorder()
+	srv.handleHealth(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+
+	var body struct {
+		Status string `json:"status"`
+		Uptime int64  `json:"uptime"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status = %q, want ok", body.Status)
+	}
+	if body.Uptime < 1 {
+		t.Fatalf("uptime = %d, want >= 1", body.Uptime)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Toast notification system replaces silent `.catch(() => [])` patterns; users now see why API calls failed instead of getting blank sections.
- Login form: inline `role=alert` red error with `aria-describedby` linking the password field to the message; autocomplete tokens added.
- Sidebar collapses to a hamburger drawer below `md` (768px) with a backdrop overlay; main content shifts to `p-4` on mobile, `p-6` on desktop.
- WebSocket reconnect upgraded from a fixed 3s loop to capped exponential backoff (1s → 2s → 4s → 8s → 16s → 30s, reset on open). Live connection indicator (green/amber/red dot) in header.
- Overview page: spinner while initial data loads; errors surface via toast.
- New `GET /healthz` endpoint (no auth) returns `{status, uptime}` for external monitors.

## Files
- `frontend/src/components/Toast.svelte` (new)
- `frontend/src/lib/stores/toast.svelte.ts` (new — `.svelte.ts` so `$state` preprocesses)
- `frontend/src/lib/ws.ts` — backoff + state observer
- `frontend/src/routes/+layout.svelte` — drawer, indicator, login a11y
- `frontend/src/routes/+page.svelte` — loading state, toast errors
- `frontend/src/routes/security/+page.svelte` — toast errors
- `internal/server/server.go` + `server_test.go` — healthz

## Test plan
- [x] `go test ./...` passes (new `TestHandleHealthReturnsStatusAndUptime`)
- [x] `bunx svelte-check` clean
- [x] `vite build` clean
- [ ] Manual: bad credentials → red inline error + aria-alert
- [ ] Manual: viewport <768px → hamburger toggles drawer; backdrop closes it
- [ ] Manual: kill backend → indicator turns red, toasts on broken endpoints; restart → indicator green, intervals visibly grow before reset
- [ ] Manual: `curl http://localhost:4200/healthz` → 200 with `status: ok`

Closes #7

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>