### PR TITLE
ci: auto-sync dependabot lockfile updates

### DIFF
--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -1,0 +1,58 @@
+name: Dependabot lockfile sync
+
+# Dependabot updates package.json but not bun.lock, so the two drift apart.
+# Any future `bun install --frozen-lockfile` would fail, and AGENTS rule 6
+# requires lockfiles to stay committed. This job regenerates the lockfile
+# on dependabot PRs and pushes the change back to the PR branch.
+#
+# Security note: github.head_ref is consumed only inside the checkout action
+# `with:` block (safe context), never interpolated into a shell `run:` step.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-lockfile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Refresh root lockfile
+        run: bun install --no-frozen-lockfile
+
+      - name: Refresh frontend lockfile
+        working-directory: frontend
+        run: bun install --no-frozen-lockfile
+
+      - name: Commit and push lockfile changes
+        run: |
+          if [[ -z "$(git status --porcelain bun.lock frontend/bun.lock)" ]]; then
+            echo "Lockfiles already in sync, nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bun.lock frontend/bun.lock
+          git commit -m "chore: sync bun.lock after dependabot bump"
+          git push


### PR DESCRIPTION
## Problem

Dependabot bumps `package.json` versions but does NOT regenerate `bun.lock`. The two files drift apart on every dependabot PR, which:

1. Violates AGENTS rule 6 (lockfiles must stay committed and consistent).
2. Breaks any future `bun install --frozen-lockfile` run — exact pain just hit the sibling `health` repo, where 4 dependabot PRs failed CI for this reason.
3. Forces a manual `bun install` + push on every dependabot PR before it can be merged cleanly.

Current CI here uses lenient `bun install` (no `--frozen-lockfile`), so failures are not visible yet, but the inconsistency is real and a single hardening of CI would surface it.

## Fix

New workflow `.github/workflows/dependabot-lockfile-sync.yml` that:

- Triggers on `pull_request` opened against `main`.
- Runs only when `github.actor == 'dependabot[bot]'`.
- Checks out the PR branch using `GITHUB_TOKEN` (so the push back trips the PR's CI).
- Runs `bun install --no-frozen-lockfile` at the repo root AND in `frontend/` (this repo has two `bun.lock` files).
- Commits any lockfile changes as `github-actions[bot]` and pushes back to the PR branch.

Permissions are scoped: `contents: write` + `pull-requests: write` only on the sync job.

Third-party action `oven-sh/setup-bun` is pinned to commit SHA per AGENTS rule 14. `actions/checkout@v6` follows the existing repo convention for first-party `actions/*` workflows.

## Test plan

- [ ] Merge this PR.
- [ ] Wait for next weekly dependabot run (or trigger one) and confirm the workflow runs on the dependabot PR.
- [ ] Confirm a follow-up commit `chore: sync bun.lock after dependabot bump` appears on the dependabot PR when a lockfile change is needed.
- [ ] Confirm no follow-up commit appears when lockfile is already in sync (e.g. `github-actions` ecosystem bumps).

Co-authored-by: Claude <noreply@anthropic.com>