### PR TITLE
ci: smoke-test the Docker image after building it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,39 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build container image
-        run: docker build .
+        run: docker build -t dashboard:ci .
+
+      # Boot the real image and assert /healthz responds. A "docker build .\"
+      # check alone misses runtime regressions (missing modules, panics during
+      # migrate, broken entrypoint, dangling symlinks from a leaky
+      # .dockerignore, etc.) — those only surface when the binary actually
+      # runs. Mirror of the notes repo guard added after a silent crash-loop
+      # made it to production.
+      - name: Boot container
+        run: |
+          docker run -d --name dashboard-smoke -p 4200:4200 dashboard:ci
+
+      - name: Wait for /healthz (max 30s)
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4200/healthz | grep -q '"status":"ok"'; then
+              echo "healthz OK after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::/healthz never responded; container logs:"
+          docker logs dashboard-smoke || true
+          exit 1
+
+      - name: Assert no fatal errors in logs
+        run: |
+          if docker logs dashboard-smoke 2>&1 | grep -E 'panic:|fatal error:|runtime error:|cannot find|undefined symbol'; then
+            echo "::error::container logged a fatal error during boot"
+            docker logs dashboard-smoke
+            exit 1
+          fi
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f dashboard-smoke || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,13 @@ ENV HOST=0.0.0.0 \
     PUBLIC_DIR=/app/frontend/build
 
 EXPOSE 4200
+
+# start-period gives migrations + entrypoint setup time to finish before the
+# first probe. After that, three failures flip the container to "unhealthy"
+# so the dashboard / external monitors can surface a crash-loop instead of it
+# sitting silently red — same pattern adopted in the notes repo after a
+# 1296-restart silent crash-loop went unnoticed for days.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+	CMD curl -fsS http://127.0.0.1:4200/healthz || exit 1
+
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## Summary
`docker-build` job ran only `docker build .`, so any runtime regression that survived compilation (panic on startup, missing asset, broken entrypoint, dangling symlink from a leaky `.dockerignore`, CSP that breaks the SPA, etc.) shipped **silently**. The sibling notes repo hit exactly this failure mode — **1296 restarts deep in production** before anyone noticed (see [notes#58](https://github.com/LiukScot/notes/pull/58)).

This PR adds the matching guard here so the same gap never bites the dashboard.

## Changes
- `.github/workflows/ci.yml` — extend `docker-build` job: boot the freshly built image, wait up to 30s for `/healthz` to return `{"status":"ok",...}`, fail if container logs contain `panic:` / `fatal error:` / `runtime error:` / `cannot find` / `undefined symbol` during boot.
- `Dockerfile` — add a `HEALTHCHECK` to the runtime stage so the docker daemon flips the container to `unhealthy` on crash-loop. Mirrors the notes-repo fix.

## Why this catches what the existing job misses
- `docker build` only verifies the image **builds**, not that the binary **runs**.
- Go unit tests (`go-build` job) test code in isolation, never the assembled artifact (binary + frontend build + entrypoint + CSP middleware + DB migrations all together).
- Playwright e2e (`e2e` job) uses dev-built binaries on the runner host, not the production image — so a Dockerfile / entrypoint / CSP regression that only affects the image would slip through.
- The smoke step exercises the same artifact that ships, with a deterministic success signal (`/healthz`).

## Test plan
- [x] Built image locally with the modified Dockerfile.
- [x] `docker run -d ...; curl /healthz` returns `{"status":"ok","uptime":0}` within 2s.
- [x] Log grep matches none of the fatal patterns on a healthy boot.
- [ ] `docker-build` job green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)