### PR TITLE
fix: codebase analysis findings 2026-05-30

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,7 @@ on:
     types: [opened]
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -33,7 +33,7 @@ jobs:
       COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
       IS_PR: ${{ github.event.issue.pull_request != null }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Save comment body to file
         # Mitigazione prompt injection: il body del commento NON viene espanso nel

--- a/frontend/src/components/GaugeRing.svelte
+++ b/frontend/src/components/GaugeRing.svelte
@@ -45,7 +45,7 @@
 			cy={center}
 			r={radius}
 			fill="none"
-			stroke="#1e1e2e"
+			style="stroke: var(--color-border)"
 			stroke-width="10"
 		/>
 		<circle
@@ -67,7 +67,7 @@
 			x={center}
 			y="60"
 			text-anchor="middle"
-			fill="#e4e4ef"
+			style="fill: var(--color-text)"
 			font-size="11"
 			font-weight="500"
 			letter-spacing="0.04em"
@@ -78,7 +78,7 @@
 			x={center}
 			y="84"
 			text-anchor="middle"
-			fill="#e4e4ef"
+			style="fill: var(--color-text)"
 			font-size="21"
 			font-weight="600"
 		>

--- a/frontend/src/components/TimeChart.svelte
+++ b/frontend/src/components/TimeChart.svelte
@@ -38,6 +38,15 @@
 
 	const fallbackHeight = 250;
 
+	// Colors mirroring CSS design tokens; ECharts config is pure JS so CSS
+	// variables cannot be used directly — keep values in sync with app.css.
+	const THEME = {
+		border:  '#1e1e2e',
+		textDim: '#8888a0',
+		text:    '#e4e4ef',
+		bgCard:  '#12121a',
+	} as const;
+
 	let { title, labels, series, yAxisLabel = '', height = '250px', zoomable = false }: Props = $props();
 	let container: HTMLDivElement | undefined;
 	let chart: EChartsType | null = null;
@@ -82,7 +91,7 @@
 					left: 12,
 					top: 8,
 					textStyle: {
-						color: '#8888a0',
+						color: THEME.textDim,
 						fontSize: 12,
 						fontWeight: 500
 					}
@@ -95,7 +104,7 @@
 					itemWidth: 8,
 					itemHeight: 8,
 					textStyle: {
-						color: '#8888a0',
+						color: THEME.textDim,
 						fontSize: 11
 					}
 				},
@@ -112,15 +121,15 @@
 								type: 'slider',
 								height: 18,
 								bottom: 8,
-								borderColor: '#1e1e2e',
+								borderColor: THEME.border,
 								backgroundColor: 'transparent',
 								fillerColor: 'rgba(0, 212, 170, 0.15)',
 								handleStyle: { color: '#00d4aa' },
 								moveHandleStyle: { color: '#00d4aa' },
-								textStyle: { color: '#8888a0', fontSize: 10 },
+								textStyle: { color: THEME.textDim, fontSize: 10 },
 								dataBackground: {
-									lineStyle: { color: '#1e1e2e' },
-									areaStyle: { color: '#1e1e2e' }
+									lineStyle: { color: THEME.border },
+									areaStyle: { color: THEME.border }
 								},
 								selectedDataBackground: {
 									lineStyle: { color: '#00d4aa' },
@@ -131,15 +140,15 @@
 					: undefined,
 				tooltip: {
 					trigger: 'axis',
-					backgroundColor: '#12121a',
-					borderColor: '#1e1e2e',
+					backgroundColor: THEME.bgCard,
+					borderColor: THEME.border,
 					textStyle: {
-						color: '#e4e4ef'
+						color: THEME.text
 					},
 					axisPointer: {
 						type: 'line',
 						lineStyle: {
-							color: '#8888a0',
+							color: THEME.textDim,
 							opacity: 0.35
 						}
 					}
@@ -150,14 +159,14 @@
 					boundaryGap: false,
 					axisLine: {
 						lineStyle: {
-							color: '#1e1e2e'
+							color: THEME.border
 						}
 					},
 					axisTick: {
 						show: false
 					},
 					axisLabel: {
-						color: '#8888a0',
+						color: THEME.textDim,
 						fontSize: 10,
 						hideOverlap: true
 					}
@@ -173,13 +182,13 @@
 						show: false
 					},
 					axisLabel: {
-						color: '#8888a0',
+						color: THEME.textDim,
 						fontSize: 10,
 						formatter: (value: number) => formatYAxisValue(value)
 					},
 					splitLine: {
 						lineStyle: {
-							color: '#1e1e2e',
+							color: THEME.border,
 							type: 'dashed'
 						}
 					}
@@ -208,7 +217,6 @@
 					};
 				})
 			},
-			{ notMerge: true }
 		);
 	}
 

--- a/frontend/src/components/TimeChart.svelte
+++ b/frontend/src/components/TimeChart.svelte
@@ -217,6 +217,7 @@
 					};
 				})
 			},
+			{ replaceMerge: ['series'] }
 		);
 	}
 

--- a/frontend/src/routes/cron/+page.svelte
+++ b/frontend/src/routes/cron/+page.svelte
@@ -218,7 +218,7 @@
 
 						{#each daysInWeek() as day}
 							<div class="relative border-r border-border last:border-r-0">
-								{#each hours as _hour}
+								{#each hours as _}
 									<div class="h-14 border-b border-border/70"></div>
 								{/each}
 

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -288,13 +289,15 @@ func jobSet(jobs []CronJob) map[string]bool {
 
 func (c *CronCollector) pruneStaleHidden(hidden map[string]bool, current map[string]bool) map[string]bool {
 	active := map[string]bool{}
-	for fingerprint := range hidden {
-		if current[fingerprint] {
-			active[fingerprint] = true
+	for fp := range hidden {
+		if current[fp] {
+			active[fp] = true
 			continue
 		}
 		if c.db != nil {
-			_, _ = c.db.Exec(`DELETE FROM cron_hidden_jobs WHERE job_id = ?`, fingerprint)
+			if _, err := c.db.Exec(`DELETE FROM cron_hidden_jobs WHERE job_id = ?`, fp); err != nil {
+				log.Printf("prune stale hidden cron job %s: %v", fp, err)
+			}
 		}
 	}
 	return active
@@ -334,7 +337,7 @@ func (c *CronCollector) resolveFiles() ([]string, []string) {
 
 func parseCronLine(raw string, source string, lineNo int) (CronJob, bool, string) {
 	line := strings.TrimSpace(raw)
-	if line == "" || strings.HasPrefix(line, "#") || strings.Contains(line, "=") && !strings.Contains(line, " ") {
+	if line == "" || strings.HasPrefix(line, "#") || (strings.Contains(line, "=") && !strings.Contains(line, " ")) {
 		return CronJob{}, false, ""
 	}
 	fields := strings.Fields(line)
@@ -420,9 +423,13 @@ func cronSourceUser(source string) string {
 	return ""
 }
 
+// fingerprintLen is the number of hex chars kept from the SHA-256 digest.
+// 16 hex chars = 64 bits: collision probability ~1e-15 for <1M distinct jobs.
+const fingerprintLen = 16
+
 func fingerprint(parts ...string) string {
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
-	return hex.EncodeToString(sum[:])[:16]
+	return hex.EncodeToString(sum[:])[:fingerprintLen]
 }
 
 func parseCronExpr(raw string) (cronExpr, error) {

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -56,6 +56,9 @@ func (f *Fail2BanCollector) GetStatus() (*Fail2BanStatus, error) {
 	}
 
 	for _, name := range jailNames {
+		if !validJailName.MatchString(name) {
+			continue
+		}
 		jail, err := f.getJailStatus(name)
 		if err != nil {
 			continue
@@ -113,6 +116,8 @@ func (f *Fail2BanCollector) getJailStatus(name string) (*JailStatus, error) {
 }
 
 var banLogPattern = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)\s+fail2ban\.\w+\s+\[\d+\]:\s+\w+\s+\[([\w.-]+)\]\s+(Ban|Unban)\s+(\S+)`)
+
+var validJailName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 	logFile := filepath.Join(f.logPath, "fail2ban.log")

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -51,9 +51,7 @@ func (f *Fail2BanCollector) GetStatus() (*Fail2BanStatus, error) {
 	}
 
 	jailNames := parseJailList(string(out))
-	status := &Fail2BanStatus{
-		TotalJails: len(jailNames),
-	}
+	status := &Fail2BanStatus{}
 
 	for _, name := range jailNames {
 		if !validJailName.MatchString(name) {
@@ -66,6 +64,7 @@ func (f *Fail2BanCollector) GetStatus() (*Fail2BanStatus, error) {
 		status.Jails = append(status.Jails, *jail)
 		status.TotalBans += jail.BanCount
 	}
+	status.TotalJails = len(status.Jails)
 
 	return status, nil
 }
@@ -117,7 +116,9 @@ func (f *Fail2BanCollector) getJailStatus(name string) (*JailStatus, error) {
 
 var banLogPattern = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+)\s+fail2ban\.\w+\s+\[\d+\]:\s+\w+\s+\[([\w.-]+)\]\s+(Ban|Unban)\s+(\S+)`)
 
-var validJailName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+// validJailName requires names to start with alphanumeric to prevent leading
+// dashes being interpreted as flags by fail2ban-client (argument injection).
+var validJailName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 func (f *Fail2BanCollector) GetRecentBans(limit int) ([]BanEvent, error) {
 	logFile := filepath.Join(f.logPath, "fail2ban.log")

--- a/internal/collectors/fail2ban_test.go
+++ b/internal/collectors/fail2ban_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetRecentBansParsesCommaMilliseconds(t *testing.T) {
@@ -65,5 +67,21 @@ func TestGetRecentBansParsesHyphenatedJailNames(t *testing.T) {
 
 	if events[0].Jail != "sshd-ddos" {
 		t.Fatalf("expected jail sshd-ddos, got %q", events[0].Jail)
+	}
+}
+
+func TestValidJailNameAcceptsNormalNames(t *testing.T) {
+	t.Parallel()
+	valid := []string{"sshd", "nginx-auth", "apache.auth", "jail_1", "a-b.c_d"}
+	for _, name := range valid {
+		assert.True(t, validJailName.MatchString(name), "expected %q to be valid", name)
+	}
+}
+
+func TestValidJailNameRejectsMalformed(t *testing.T) {
+	t.Parallel()
+	invalid := []string{"--version", "jail name", "jail/name", ""}
+	for _, name := range invalid {
+		assert.False(t, validJailName.MatchString(name), "expected %q to be invalid", name)
 	}
 }

--- a/internal/collectors/system_history.go
+++ b/internal/collectors/system_history.go
@@ -26,6 +26,11 @@ const (
 	retain1mHours = 24
 	retain5mDays  = 7
 	retain1hDays  = 30
+
+	secondsPerHour = 3600
+	secondsPerDay  = 86400
+	bucket5mSecs   = 5 * 60
+	bucket1hSecs   = secondsPerHour
 )
 
 type SystemHistory struct {
@@ -123,14 +128,14 @@ func (h *SystemHistory) retentionLoop(ctx context.Context) {
 // runRetention downsamples 1m→5m past 24h, 5m→1h past 7d, deletes 1h past 30d.
 func (h *SystemHistory) runRetention() error {
 	now := time.Now().Unix()
-	cutoff1m := now - int64(retain1mHours*3600)
-	cutoff5m := now - int64(retain5mDays*86400)
-	cutoff1h := now - int64(retain1hDays*86400)
+	cutoff1m := now - int64(retain1mHours*secondsPerHour)
+	cutoff5m := now - int64(retain5mDays*secondsPerDay)
+	cutoff1h := now - int64(retain1hDays*secondsPerDay)
 
-	if err := h.downsample(resolution1m, resolution5m, cutoff1m, 300); err != nil {
+	if err := h.downsample(resolution1m, resolution5m, cutoff1m, bucket5mSecs); err != nil {
 		return fmt.Errorf("downsample 1m→5m: %w", err)
 	}
-	if err := h.downsample(resolution5m, resolution1h, cutoff5m, 3600); err != nil {
+	if err := h.downsample(resolution5m, resolution1h, cutoff5m, bucket1hSecs); err != nil {
 		return fmt.Errorf("downsample 5m→1h: %w", err)
 	}
 	if _, err := h.db.Exec(

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -63,6 +63,11 @@ var migrations = []string{
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_metrics_history_resolution_ts
 		ON metrics_history(resolution, timestamp)`,
+	// Query() filters by timestamp only (no resolution filter), so the composite
+	// (resolution, timestamp) index above is skipped. A standalone timestamp
+	// index allows SQLite to use a range scan instead of a full table scan.
+	`CREATE INDEX IF NOT EXISTS idx_metrics_history_ts
+		ON metrics_history(timestamp)`,
 }
 
-const SchemaVersion = 6
+const SchemaVersion = 7

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,6 +133,8 @@ func (s *Server) Start() error {
 	return srv.ListenAndServe()
 }
 
+const hstsMaxAgeSeconds = 365 * 24 * 3600
+
 // securityHeaders sets baseline response headers that harden the SPA + cookie
 // session against clickjacking, MIME sniffing, and XSS.
 func (s *Server) securityHeaders(next http.Handler) http.Handler {
@@ -144,8 +146,11 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		// Allow inline styles (Tailwind) and SvelteKit's bootstrap inline script
 		// via per-script SHA-256 hashes computed at startup — never 'unsafe-inline'.
 		h.Set("Content-Security-Policy", s.csp)
-		// Tell browsers to only use HTTPS for this origin for 1 year.
-		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		// Only emit HSTS when running under HTTPS; emitting it over plain HTTP
+		// pins the domain to HTTPS in the browser for a year with no benefit.
+		if s.cfg.CookieSecure {
+			h.Set("Strict-Transport-Security", fmt.Sprintf("max-age=%d; includeSubDomains", hstsMaxAgeSeconds))
+		}
 		next.ServeHTTP(w, r)
 	})
 }
@@ -194,14 +199,20 @@ func (s *Server) withAuth(handler http.HandlerFunc) http.HandlerFunc {
 
 // --- Auth handlers ---
 
+const loginMaxBodyBytes = 4096
+
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	r.Body = http.MaxBytesReader(w, r.Body, loginMaxBodyBytes)
 	var body struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+		return
+	}
+	if len(body.Email) > 254 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid credentials"})
 		return
 	}
 
@@ -522,7 +533,7 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	// If no frontend build exists, serve a placeholder
 	if _, err := fs.Stat(os.DirFS(publicDir), "."); err != nil {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<h1>Dashboard</h1><p>Frontend not built yet. Run <code>cd frontend && bun run build</code></p>"))
+		_, _ = w.Write([]byte("<h1>Dashboard</h1><p>Frontend not built yet. Run <code>cd frontend && bun run build</code></p>"))
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -73,7 +73,21 @@ func TestHandleLoginRejectsOversizedBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, res.Code)
 }
 
-func TestHandleLoginRejectsMalformedJSON(t *testing.T) {
+func TestHandleLoginRejectsOversizedEmail(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, nil)
+
+	// 251 'a' chars + "@b.c" = 255 bytes, over the 254-byte RFC 5321 limit.
+	email := strings.Repeat("a", 251) + "@b.c"
+	body := fmt.Sprintf(`{"email":%q,"password":"pw"}`, email)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	srv.handleLogin(res, req)
+
+	assert.Equal(t, http.StatusBadRequest, res.Code)
+}
+
+func TestHandleLoginMalformedJSON(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t, nil, nil)
 
@@ -496,6 +510,37 @@ func TestSecurityHeadersSet(t *testing.T) {
 	for header, want := range checks {
 		assert.Equal(t, want, res.Header().Get(header), "header %s", header)
 	}
+}
+
+func TestSecurityHeadersNoHSTSWhenCookieSecureDisabled(t *testing.T) {
+	t.Parallel()
+	srv := &Server{cfg: &config.Config{CookieSecure: false}}
+	wrapped := srv.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	wrapped.ServeHTTP(res, req)
+
+	assert.Empty(t, res.Header().Get("Strict-Transport-Security"),
+		"HSTS must not be emitted over plain HTTP (CookieSecure=false)")
+}
+
+func TestSecurityHeadersSetsHSTSWhenCookieSecureEnabled(t *testing.T) {
+	t.Parallel()
+	srv := &Server{cfg: &config.Config{CookieSecure: true}}
+	wrapped := srv.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	res := httptest.NewRecorder()
+	wrapped.ServeHTTP(res, req)
+
+	hsts := res.Header().Get("Strict-Transport-Security")
+	assert.Contains(t, hsts, "max-age=", "HSTS header must be set when running over HTTPS")
+	assert.Contains(t, hsts, "includeSubDomains")
 }
 
 func TestCorsMiddlewareAllowsConfiguredOrigin(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -87,6 +87,21 @@ func TestHandleLoginRejectsOversizedEmail(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, res.Code)
 }
 
+func TestHandleLoginAllowsEmailAtMaxLengthBoundary(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, nil)
+
+	// 250 'a' chars + "@b.c" = 254 bytes (RFC 5321 max — must pass validation).
+	email := strings.Repeat("a", 250) + "@b.c"
+	body := fmt.Sprintf(`{"email":%q,"password":"pw"}`, email)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	srv.handleLogin(res, req)
+
+	// Validation passes; auth fails with 401 (unknown user), not 400.
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
 func TestHandleLoginMalformedJSON(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t, nil, nil)


### PR DESCRIPTION
## Summary

Weekly automated codebase analysis — 17 fixes shipped across security, quality, performance, and CI.

**Security:**
- Validate `email` field length ≤254 bytes in `handleLogin` before passing to DB query
- Emit `Strict-Transport-Security` only when `CookieSecure=true`; previously sent over plain HTTP with no benefit
- Validate fail2ban jail names against `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$` to prevent argument injection into `fail2ban-client`

**Quality / constants:**
- Extract `loginMaxBodyBytes`, `hstsMaxAgeSeconds`, `fingerprintLen`, `secondsPerHour`/`secondsPerDay`/`bucket5mSecs`/`bucket1hSecs` replacing bare magic literals
- Add parentheses to `parseCronLine` `&&`/`||` condition (readability, semantics unchanged)
- Log `pruneStaleHidden` DELETE errors instead of silently discarding them (`_, _`)
- Make `w.Write` error discard explicit (`_, _ =`)

**Performance / DB:**
- Add `idx_metrics_history_ts ON metrics_history(timestamp)` — `Query()` filters only by `timestamp` with no `resolution` filter, so the composite `(resolution, timestamp)` index was never used (full-table scan every history call). Bump `SchemaVersion` → 7.

**Frontend:**
- `TimeChart`: introduce `THEME` const centralising ECharts color values that mirror CSS tokens; switch from `notMerge:true` to `{replaceMerge:['series']}` — removes stale series without full chart rebuild on every 3-second tick
- `GaugeRing`: replace hardcoded `#1e1e2e`/`#e4e4ef` with `var(--color-border)`/`var(--color-text)`
- `cron/+page.svelte`: rename unused loop var `_hour` → `_`

**CI:**
- `claude-mention.yml`: fix `actions/checkout@v6` (non-existent tag) → `@v4`
- `auto-assign.yml`: add missing `contents: read` to permissions block (AGENTS.md §14)

**Tests added (AGENTS.md §9):**
- `TestHandleLoginRejectsOversizedEmail`
- `TestSecurityHeadersNoHSTSWhenCookieSecureDisabled`
- `TestSecurityHeadersSetsHSTSWhenCookieSecureEnabled`
- `TestValidJailNameAcceptsNormalNames`
- `TestValidJailNameRejectsMalformed`

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/dashboard/issues/59

## Sub-analyst reports

- **Security:** No rate limiting on login (deferred); HSTS over HTTP (shipped); email length (shipped); jail name injection (shipped)
- **Quality:** `formatBytes` duplication (2 instances, below AGENTS.md §3 threshold — not abstracted); hardcoded hex in ECharts/SVG (shipped); magic numbers (shipped)
- **Bugs:** DOM/DOW wildcard logic — analysis shows code is actually correct (wildcard fields always match); operator precedence (cosmetic fix shipped)
- **Tests:** 5 new tests for shipped security validations; remaining gaps deferred to issue #59
- **Deps:** `cookie@0.6.0` CVE via `@sveltejs/kit` bump (needs `bun` — deferred); `golang:1.26` Dockerfile tag is valid (dep analyst was incorrect); `actions/checkout@v6` (shipped)
- **Performance:** Missing `timestamp` index (shipped); full file scan / N+1 fail2ban / log scan (deferred — complex reverse-read logic)

---
Generated automatically by Codebase Analyst — 2026-05-30