### PR TITLE
fix: resolve 3 deferred findings (ws goroutine leak, echarts chunk, session PII)

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -39,5 +39,5 @@ func main() {
 
 	srv := server.New(cfg, authSvc, sysColl, sysHist, dockerColl, f2bColl, logColl, cronColl)
 
-	log.Fatal(srv.Start())
+	log.Fatal(srv.Start(ctx))
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -72,6 +72,37 @@ describe('api client', () => {
 		await expect(api.session()).rejects.toThrow(/Expected JSON/);
 	});
 
+	it('session returns only the authenticated flag (no user PII)', async () => {
+		const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+		mock.mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ 'content-type': 'application/json' }),
+			json: async () => ({ authenticated: true })
+		});
+
+		const session = await api.session();
+
+		const [url] = mock.mock.calls[0];
+		expect(url).toBe('/api/v1/auth/session');
+		expect(session).toEqual({ authenticated: true });
+		expect('user' in session).toBe(false);
+	});
+
+	it('me returns the user object from the auth-gated endpoint', async () => {
+		const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+		mock.mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ 'content-type': 'application/json' }),
+			json: async () => ({ id: 1, email: 'alice@example.com' })
+		});
+
+		const user = await api.me();
+
+		const [url] = mock.mock.calls[0];
+		expect(url).toBe('/api/v1/auth/me');
+		expect(user).toEqual({ id: 1, email: 'alice@example.com' });
+	});
+
 	it('systemHistory passes range as query string', async () => {
 		const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
 		mock.mockResolvedValueOnce({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -148,7 +148,6 @@ export interface LogEntry {
 
 export interface SessionResponse {
 	authenticated: boolean;
-	user?: { id: number; email: string };
 }
 
 export interface CronWeek {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -34,10 +34,16 @@
 		}
 	}
 
+	async function loadUser(): Promise<typeof user> {
+		const session = await api.session();
+		// /session is a public endpoint and returns no PII; fetch user details
+		// from the auth-gated /me only once we know the session is valid.
+		return session.authenticated ? await api.me() : null;
+	}
+
 	onMount(async () => {
 		try {
-			const session = await api.session();
-			user = session.authenticated ? (session.user ?? null) : null;
+			user = await loadUser();
 		} catch {
 			user = null;
 		} finally {
@@ -100,8 +106,7 @@
 				const data = new FormData(form);
 				try {
 					await api.login(data.get('email') as string, data.get('password') as string);
-					const session = await api.session();
-					user = session.authenticated ? (session.user ?? null) : null;
+					user = await loadUser();
 					loginError = '';
 				} catch (err) {
 					loginError = err instanceof Error ? err.message : 'Sign in failed';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,8 +13,11 @@
 	import { toastError } from '$lib/stores/toast.svelte';
 	import { formatBytes } from '$lib/format';
 	import GaugeRing from '../components/GaugeRing.svelte';
-	import TimeChart from '../components/TimeChart.svelte';
 	import ContainerTable from '../components/ContainerTable.svelte';
+
+	// ECharts is heavy (~552 KB); load TimeChart lazily so it lands in its own
+	// chunk (see vite.config.ts manualChunks) instead of the main route bundle.
+	const timeChart = import('../components/TimeChart.svelte');
 
 	let system = $state<SystemMetrics | null>(null);
 	let network = $state<NetworkMetrics[]>([]);
@@ -231,6 +234,14 @@
 
 </script>
 
+{#snippet chartSkeleton()}
+	<div
+		class="h-64 w-full animate-pulse rounded-lg bg-bg-hover"
+		role="status"
+		aria-label="Loading chart"
+	></div>
+{/snippet}
+
 <div class="space-y-6">
 	{#if initialLoading}
 		<div class="flex items-center justify-center py-16">
@@ -317,22 +328,30 @@
 	<!-- Charts -->
 	<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
 		<div class="bg-bg-card border border-border rounded-xl p-4">
-			<TimeChart
-				title={`${metrics[selectedMetric].label} ${historyLive ? '(live)' : `(${historyRange})`}`}
-				labels={metricChartLabels}
-				series={metricChartSeries}
-				yAxisLabel="%"
-				zoomable={!historyLive}
-			/>
+			{#await timeChart}
+				{@render chartSkeleton()}
+			{:then { default: TimeChart }}
+				<TimeChart
+					title={`${metrics[selectedMetric].label} ${historyLive ? '(live)' : `(${historyRange})`}`}
+					labels={metricChartLabels}
+					series={metricChartSeries}
+					yAxisLabel="%"
+					zoomable={!historyLive}
+				/>
+			{/await}
 		</div>
 		<div class="bg-bg-card border border-border rounded-xl p-4">
-			<TimeChart
-				title={historyLive ? 'Network Bandwidth (live)' : `Network Bandwidth (${historyRange})`}
-				labels={netChartLabels}
-				series={netChartSeries}
-				yAxisLabel="KB/s"
-				zoomable={!historyLive}
-			/>
+			{#await timeChart}
+				{@render chartSkeleton()}
+			{:then { default: TimeChart }}
+				<TimeChart
+					title={historyLive ? 'Network Bandwidth (live)' : `Network Bandwidth (${historyRange})`}
+					labels={netChartLabels}
+					series={netChartSeries}
+					yAxisLabel="KB/s"
+					zoomable={!historyLive}
+				/>
+			{/await}
 		</div>
 	</div>
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,19 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	build: {
+		rollupOptions: {
+			output: {
+				// Isolate ECharts (~552 KB) into its own chunk so it stays out of
+				// the main route bundle and only loads when a chart is rendered.
+				manualChunks(id) {
+					if (id.includes('node_modules/echarts') || id.includes('node_modules/zrender')) {
+						return 'echarts';
+					}
+				}
+			}
+		}
+	},
 	server: {
 		proxy: {
 			'/api': 'http://localhost:4200',

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -108,9 +109,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/", s.handleStatic)
 }
 
-func (s *Server) Start() error {
-	// Start WebSocket broadcast
-	s.wsHandler.StartBroadcastLoop(3 * time.Second)
+func (s *Server) Start(ctx context.Context) error {
+	// Start WebSocket broadcast; ctx cancellation stops the loop and its ticker
+	// on shutdown so neither the goroutine nor the ticker leaks.
+	s.wsHandler.StartBroadcastLoop(ctx, 3*time.Second)
 
 	// Initial collection to populate data
 	if _, err := s.sysColl.Collect(); err != nil {
@@ -265,24 +267,19 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// handleSession is a public endpoint, so it returns only the boolean auth
+// state — never user PII (id/email). The authenticated client fetches user
+// details from the auth-gated /api/v1/auth/me.
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
-	response := map[string]any{"authenticated": false}
+	authenticated := false
 
-	cookie, err := r.Cookie(auth.SessionCookieName)
-	if err != nil {
-		writeJSON(w, http.StatusOK, response)
-		return
+	if cookie, err := r.Cookie(auth.SessionCookieName); err == nil {
+		if _, err := s.authSvc.ValidateSession(cookie.Value); err == nil {
+			authenticated = true
+		}
 	}
 
-	user, err := s.authSvc.ValidateSession(cookie.Value)
-	if err != nil {
-		writeJSON(w, http.StatusOK, response)
-		return
-	}
-
-	response["authenticated"] = true
-	response["user"] = user
-	writeJSON(w, http.StatusOK, response)
+	writeJSON(w, http.StatusOK, map[string]bool{"authenticated": authenticated})
 }
 
 func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -197,7 +197,7 @@ func TestHandleSessionReturnsAuthenticatedFalseWithoutCookie(t *testing.T) {
 	assert.False(t, body.Authenticated)
 }
 
-func TestHandleSessionReturnsUserWhenAuthenticated(t *testing.T) {
+func TestHandleSessionAuthenticatedOmitsUserPII(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t, nil, nil)
 	sid := loginUser(t, srv, "alice@example.com", "pw")
@@ -208,16 +208,15 @@ func TestHandleSessionReturnsUserWhenAuthenticated(t *testing.T) {
 	srv.handleSession(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code)
-	var body struct {
-		Authenticated bool `json:"authenticated"`
-		User          *struct {
-			Email string `json:"email"`
-		} `json:"user"`
-	}
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-	assert.True(t, body.Authenticated)
-	require.NotNil(t, body.User)
-	assert.Equal(t, "alice@example.com", body.User.Email)
+
+	// The public session endpoint must not leak user id/email; only the
+	// authenticated boolean is allowed in the body.
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&raw))
+	assert.Equal(t, true, raw["authenticated"])
+	_, hasUser := raw["user"]
+	assert.False(t, hasUser, "session response must not include a user object")
+	assert.NotContains(t, res.Body.String(), "alice@example.com")
 }
 
 // --- withAuth ---------------------------------------------------------------

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -142,10 +143,22 @@ type MetricsBroadcast struct {
 	Docker  []collectors.ContainerStats `json:"docker,omitempty"`
 }
 
-func (ws *WSHandler) StartBroadcastLoop(interval time.Duration) {
+// StartBroadcastLoop runs the metrics broadcast goroutine until ctx is
+// cancelled. The returned channel closes once the goroutine has exited and the
+// ticker is stopped, letting a caller wait for a clean shutdown.
+func (ws *WSHandler) StartBroadcastLoop(ctx context.Context, interval time.Duration) <-chan struct{} {
 	ticker := time.NewTicker(interval)
+	done := make(chan struct{})
 	go func() {
-		for range ticker.C {
+		defer close(done)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
 			if ws.hub.ClientCount() == 0 {
 				continue
 			}
@@ -171,4 +184,5 @@ func (ws *WSHandler) StartBroadcastLoop(interval time.Duration) {
 			ws.hub.Broadcast(data)
 		}
 	}()
+	return done
 }

--- a/internal/server/ws_test.go
+++ b/internal/server/ws_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -174,6 +175,24 @@ func TestHubBroadcastConcurrentWriteSafe(t *testing.T) {
 
 	_ = client.Close()
 	<-drained
+}
+
+func TestStartBroadcastLoopStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	// The broadcast goroutine must return (and stop its ticker) promptly
+	// after the context is cancelled, otherwise it leaks past shutdown.
+	ws := &WSHandler{hub: NewHub()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := ws.StartBroadcastLoop(ctx, time.Hour)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("broadcast loop did not return within 1s of context cancellation")
+	}
 }
 
 func TestHandleUpgradeRejectsUnauthenticated(t *testing.T) {


### PR DESCRIPTION
Resolves 3 of the deferred findings tracked in #68.

> Note: #68 lists 10 findings; this PR addresses only 3, so it intentionally does **not** use `Closes #68` (that would prematurely close the other 7).

## 1. WebSocket broadcast goroutine leak (`ws.go`)
`StartBroadcastLoop` spawned a goroutine driven by a `time.Ticker` that was never stopped and took no context, so on server shutdown both the goroutine and the ticker leaked.

**Fix:** thread a `context.Context` from `main.go` → `Server.Start` → `StartBroadcastLoop`, `select` on `ctx.Done()`, `defer ticker.Stop()`. The function returns a `done` channel that closes when the goroutine exits, so shutdown is observable (and testable).

## 2. ECharts bundled in the main route chunk (`+page.svelte`, `vite.config.ts`)
`TimeChart` imported ECharts at module load, pulling ~552 KB (188 KB gzip) into the overview route's main bundle.

**Fix:** lazy-import `TimeChart` behind `{#await}` with a token-based pulsing **skeleton** placeholder, and add a `manualChunks` rule isolating echarts/zrender. Verified against the build: the overview page node statically imports only small chunks; the 549 KB echarts chunk is fetched on demand via dynamic import.

## 3. Session endpoint returns user PII (`server.go`)
Public `GET /api/v1/auth/session` (no `withAuth`) returned the user's `id` + `email` when a session cookie was present.

**Fix:** response reduced to `{authenticated: bool}` only. The SvelteKit layout now hydrates the user from the already auth-gated `/api/v1/auth/me` after `authenticated=true`. The auth gate and the sidebar email display keep working (verified manually against a running server and via the Go/Playwright suites).

## Tests
- Go: `TestStartBroadcastLoopStopsOnContextCancel` (returns <1s after cancel), `TestHandleSessionAuthenticatedOmitsUserPII` (no `user` key, no email leak).
- Vitest: `session` returns only `{authenticated}`, `me` returns the user object.

## Verification (all green)
- `go vet ./...` + `go test ./...` — pass
- `bunx svelte-check` — 0 errors
- `bun run test` (vitest) — 23 passed
- `bun run build` — echarts split into its own 549 KB chunk, out of the main bundle
- `bunx playwright test` — 8 passed (auth + cron + metrics + security API-contract guards)
- Manual: authenticated `/session` → `{"authenticated":true}` (no id/email); `/me` → `{id,email}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)