### PR TITLE
test: cover handleLogs, handleFail2BanBans, clampedLimit

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -776,3 +776,26 @@ func TestHandleFail2BanBansReturnsEmptyWhenNoLogFile(t *testing.T) {
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&events))
 	assert.Empty(t, events)
 }
+
+func TestClampedLimit(t *testing.T) {
+	t.Parallel()
+	const def = 50
+	cases := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"absent uses default", "", def},
+		{"non-numeric uses default", "?limit=abc", def},
+		{"zero uses default", "?limit=0", def},
+		{"negative uses default", "?limit=-5", def},
+		{"in range passes through", "?limit=200", 200},
+		{"above max is clamped", "?limit=99999", maxQueryLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/x"+tc.query, nil)
+			assert.Equal(t, tc.want, clampedLimit(req, def))
+		})
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -719,3 +719,60 @@ func TestServerEndToEndAuthFlow(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&post))
 	assert.True(t, post.Authenticated)
 }
+
+// --- security handlers: logs + fail2ban bans -------------------------------
+
+func TestHandleLogsRejectsUnitFilterTooLong(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, nil)
+
+	unit := strings.Repeat("a", maxUnitFilterBytes+1)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/security/logs?unit="+unit, nil)
+	res := httptest.NewRecorder()
+	srv.handleLogs(res, req)
+
+	assert.Equal(t, http.StatusBadRequest, res.Code)
+}
+
+func TestHandleLogsRejectsPriorityOutOfRange(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/security/logs?priority=9", nil)
+	res := httptest.NewRecorder()
+	srv.handleLogs(res, req)
+
+	assert.Equal(t, http.StatusBadRequest, res.Code)
+}
+
+func TestHandleLogsReturnsEmptyWhenNoLogFiles(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, func(s *Server) {
+		s.logColl = collectors.NewLogCollector(t.TempDir())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/security/logs", nil)
+	res := httptest.NewRecorder()
+	srv.handleLogs(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	var entries []collectors.LogEntry
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&entries))
+	assert.Empty(t, entries)
+}
+
+func TestHandleFail2BanBansReturnsEmptyWhenNoLogFile(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(t, nil, func(s *Server) {
+		s.f2bColl = collectors.NewFail2BanCollector(t.TempDir())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/security/fail2ban/bans", nil)
+	res := httptest.NewRecorder()
+	srv.handleFail2BanBans(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	var events []collectors.BanEvent
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&events))
+	assert.Empty(t, events)
+}


### PR DESCRIPTION
Addresses the `test-gap-handle-fail2ban-bans` deferred finding from #74: the `/api/v1/security/logs` and `/api/v1/security/fail2ban/bans` handlers had no test.

## Tests added
- `handleLogs` rejects a unit filter longer than `maxUnitFilterBytes` → 400
- `handleLogs` rejects priority outside 0-7 → 400
- `handleLogs` returns empty when no log files exist → 200
- `handleFail2BanBans` returns empty when the fail2ban log is absent → 200
- `clampedLimit` table test (absent / non-numeric / ≤0 / in-range / above-max clamp)

## Notes
- Handlers are called directly, matching the existing sibling pattern (`TestHandleSystemHistory*`, `TestHandleCronWeek*`). Auth (401) is enforced by the `withAuth` middleware and already covered by `TestWithAuthRejects*`, so it isn't re-tested per route.
- The finding's suggested `s.handler(...); assert 401` would not work — these handlers have no inline auth check, so a direct call never 401s. Coverage targets the handlers' own validation + the clamp helper instead.

`go vet` + full `go test ./...` green. Part of #74.