### PR TITLE
Implement approved deferred findings (security, perf, tests)

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -29,6 +29,7 @@ func main() {
 	sysColl := collectors.NewSystemCollector(cfg.ProcPath)
 	sysHist := collectors.NewSystemHistory(database, sysColl, time.Duration(cfg.MetricsInterval)*time.Second)
 	dockerColl := collectors.NewDockerCollector(cfg.DockerSocket)
+	defer dockerColl.Close()
 	f2bColl := collectors.NewFail2BanCollector(cfg.LogPath)
 	logColl := collectors.NewLogCollector(cfg.LogPath)
 	cronColl := collectors.NewCronCollector(database, cfg.CronPaths, cfg.LogPath)

--- a/frontend/src/components/TimeChart.svelte
+++ b/frontend/src/components/TimeChart.svelte
@@ -38,14 +38,38 @@
 
 	const fallbackHeight = 250;
 
-	// Colors mirroring CSS design tokens; ECharts config is pure JS so CSS
-	// variables cannot be used directly — keep values in sync with app.css.
-	const THEME = {
-		border:  '#1e1e2e',
+	interface Theme {
+		border: string;
+		textDim: string;
+		text: string;
+		bgCard: string;
+		accent: string;
+	}
+
+	// ECharts config is plain JS and cannot consume CSS variables directly, so
+	// the design tokens are read once at runtime from the :root custom
+	// properties (see app.css @theme). The literals here are only a pre-mount
+	// fallback and stay in sync with app.css by reading the same tokens below.
+	const THEME: Theme = $state({
+		border: '#1e1e2e',
 		textDim: '#8888a0',
-		text:    '#e4e4ef',
-		bgCard:  '#12121a',
-	} as const;
+		text: '#e4e4ef',
+		bgCard: '#12121a',
+		accent: '#00d4aa'
+	});
+
+	function readToken(name: string, fallback: string): string {
+		const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+		return value || fallback;
+	}
+
+	function loadTheme(): void {
+		THEME.border = readToken('--color-border', THEME.border);
+		THEME.textDim = readToken('--color-text-dim', THEME.textDim);
+		THEME.text = readToken('--color-text', THEME.text);
+		THEME.bgCard = readToken('--color-bg-card', THEME.bgCard);
+		THEME.accent = readToken('--color-accent', THEME.accent);
+	}
 
 	let { title, labels, series, yAxisLabel = '', height = '250px', zoomable = false }: Props = $props();
 	let container: HTMLDivElement | undefined;
@@ -67,6 +91,8 @@
 
 	function toRgba(hexColor: string, alpha: number): string {
 		const match = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hexColor);
+		// Fall back to the (always valid) accent literal rather than recursing
+		// on THEME.accent, which could itself be a malformed CSS value.
 		if (!match) return `rgba(0, 212, 170, ${alpha})`;
 
 		const [, red, green, blue] = match;
@@ -123,17 +149,17 @@
 								bottom: 8,
 								borderColor: THEME.border,
 								backgroundColor: 'transparent',
-								fillerColor: 'rgba(0, 212, 170, 0.15)',
-								handleStyle: { color: '#00d4aa' },
-								moveHandleStyle: { color: '#00d4aa' },
+								fillerColor: toRgba(THEME.accent, 0.15),
+								handleStyle: { color: THEME.accent },
+								moveHandleStyle: { color: THEME.accent },
 								textStyle: { color: THEME.textDim, fontSize: 10 },
 								dataBackground: {
 									lineStyle: { color: THEME.border },
 									areaStyle: { color: THEME.border }
 								},
 								selectedDataBackground: {
-									lineStyle: { color: '#00d4aa' },
-									areaStyle: { color: 'rgba(0, 212, 170, 0.18)' }
+									lineStyle: { color: THEME.accent },
+									areaStyle: { color: toRgba(THEME.accent, 0.18) }
 								}
 							}
 						]
@@ -194,7 +220,7 @@
 					}
 				},
 				series: safeSeries.map((item) => {
-					const color = item.color || '#00d4aa';
+					const color = item.color || THEME.accent;
 					return {
 						name: item.name,
 						type: 'line',
@@ -224,6 +250,7 @@
 	onMount(() => {
 		if (!container) return;
 
+		loadTheme();
 		chart = init(container, undefined, { renderer: 'canvas' });
 		resizeObserver = new ResizeObserver(() => chart?.resize());
 		resizeObserver.observe(container);

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './format';
+
+describe('formatBytes', () => {
+	it('returns 0 B for zero and negative input', () => {
+		expect(formatBytes(0)).toBe('0 B');
+		expect(formatBytes(-5)).toBe('0 B');
+	});
+
+	it('formats bytes below 1 KB without a unit jump', () => {
+		expect(formatBytes(512)).toBe('512.0 B');
+	});
+
+	it('scales into KB, MB, GB, TB at 1024 boundaries', () => {
+		expect(formatBytes(1024)).toBe('1.0 KB');
+		expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+		expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0 GB');
+		expect(formatBytes(1024 ** 4)).toBe('1.0 TB');
+	});
+
+	it('rounds to one decimal place', () => {
+		expect(formatBytes(1536)).toBe('1.5 KB');
+	});
+
+	it('caps at the largest unit instead of overflowing past TB', () => {
+		expect(formatBytes(1024 ** 5)).toBe('1024.0 TB');
+	});
+});

--- a/frontend/src/lib/stores/toast.svelte.test.ts
+++ b/frontend/src/lib/stores/toast.svelte.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pushToast, dismissToast, toastError, getToasts } from './toast.svelte';
+
+function drain(): void {
+	for (const t of getToasts()) {
+		dismissToast(t.id);
+	}
+}
+
+describe('toast store', () => {
+	beforeEach(() => {
+		drain();
+	});
+
+	describe('toastError', () => {
+		it('uses the Error message when given an Error', () => {
+			toastError(new Error('boom'), 'fallback');
+			const toasts = getToasts();
+			expect(toasts).toHaveLength(1);
+			expect(toasts[0].kind).toBe('error');
+			expect(toasts[0].message).toBe('boom');
+		});
+
+		it('uses the fallback message for non-Error values', () => {
+			toastError('a string', 'something failed');
+			expect(getToasts()[0].message).toBe('something failed');
+		});
+	});
+
+	describe('auto-dismiss timer', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('removes the toast after the duration elapses', () => {
+			pushToast('info', 'hello', 5000);
+			expect(getToasts()).toHaveLength(1);
+
+			vi.advanceTimersByTime(4999);
+			expect(getToasts()).toHaveLength(1);
+
+			vi.advanceTimersByTime(1);
+			expect(getToasts()).toHaveLength(0);
+		});
+
+		it('never auto-dismisses when duration is zero', () => {
+			pushToast('info', 'sticky', 0);
+			vi.advanceTimersByTime(60000);
+			expect(getToasts()).toHaveLength(1);
+		});
+
+		it('manual dismiss cancels the pending timer', () => {
+			const id = pushToast('info', 'transient', 5000);
+			dismissToast(id);
+			expect(getToasts()).toHaveLength(0);
+
+			// Advancing past the original duration must not throw or double-remove.
+			vi.advanceTimersByTime(5000);
+			expect(getToasts()).toHaveLength(0);
+		});
+	});
+});

--- a/frontend/src/lib/ws.test.ts
+++ b/frontend/src/lib/ws.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribe, subscribeState, getState, type MetricsMessage } from './ws';
+
+// Minimal WebSocket double. The real ws module only touches readyState, the
+// onopen/onmessage/onclose/onerror handlers, and close(); jsdom ships no
+// WebSocket, so we stand in a controllable fake and drive the handlers
+// manually to simulate the connection lifecycle.
+class FakeWebSocket {
+	static instances: FakeWebSocket[] = [];
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+
+	readyState = FakeWebSocket.CONNECTING;
+	url: string;
+	onopen: (() => void) | null = null;
+	onmessage: ((ev: { data: string }) => void) | null = null;
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	close = vi.fn(() => {
+		this.readyState = FakeWebSocket.CLOSED;
+	});
+
+	constructor(url: string) {
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	open() {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+
+	emit(msg: MetricsMessage) {
+		this.onmessage?.({ data: JSON.stringify(msg) });
+	}
+
+	serverClose() {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.();
+	}
+
+	static last(): FakeWebSocket {
+		return FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+	}
+}
+
+describe('ws client', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		FakeWebSocket.instances = [];
+		vi.stubGlobal('WebSocket', FakeWebSocket);
+	});
+
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('opens a socket on first subscribe and reports connected on open', () => {
+		const states: string[] = [];
+		const stopState = subscribeState((s) => states.push(s));
+
+		const stop = subscribe(() => {});
+		expect(FakeWebSocket.instances).toHaveLength(1);
+
+		// Derives ws/wss from the page protocol and targets /ws.
+		expect(FakeWebSocket.last().url).toMatch(/^wss?:\/\/[^/]+\/ws$/);
+		expect(getState()).toBe('connecting');
+
+		FakeWebSocket.last().open();
+		expect(getState()).toBe('connected');
+		expect(states).toContain('connecting');
+		expect(states).toContain('connected');
+
+		stop();
+		stopState();
+	});
+
+	it('delivers parsed metrics frames to listeners', () => {
+		const received: MetricsMessage[] = [];
+		const stop = subscribe((msg) => received.push(msg));
+
+		FakeWebSocket.last().open();
+		FakeWebSocket.last().emit({ type: 'metrics', system: undefined });
+
+		expect(received).toHaveLength(1);
+		expect(received[0].type).toBe('metrics');
+
+		stop();
+	});
+
+	it('does not throw on a malformed frame and keeps the connection', () => {
+		const received: MetricsMessage[] = [];
+		const stop = subscribe((msg) => received.push(msg));
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		FakeWebSocket.last().open();
+		FakeWebSocket.last().onmessage?.({ data: 'not json{' });
+
+		expect(received).toHaveLength(0);
+		expect(errSpy).toHaveBeenCalled();
+
+		errSpy.mockRestore();
+		stop();
+	});
+
+	it('reconnects with backoff after an unexpected close while subscribed', () => {
+		const stop = subscribe(() => {});
+		FakeWebSocket.last().open();
+		expect(FakeWebSocket.instances).toHaveLength(1);
+
+		FakeWebSocket.last().serverClose();
+		expect(getState()).toBe('disconnected');
+
+		// Backoff is scheduled, not immediate.
+		expect(FakeWebSocket.instances).toHaveLength(1);
+		vi.advanceTimersByTime(1000);
+		expect(FakeWebSocket.instances).toHaveLength(2);
+
+		stop();
+	});
+
+	it('does not reconnect after the last listener unsubscribes', () => {
+		const stop = subscribe(() => {});
+		FakeWebSocket.last().open();
+
+		stop();
+		// Unsubscribe closes the socket; its onclose must not schedule a retry.
+		FakeWebSocket.last().serverClose();
+		vi.advanceTimersByTime(60000);
+
+		expect(FakeWebSocket.instances).toHaveLength(1);
+		expect(getState()).toBe('disconnected');
+	});
+});

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,6 +23,11 @@ var (
 // silently truncated, hiding the fact that the rest is unchecked.
 const bcryptMaxPasswordBytes = 72
 
+// bcryptWorkFactor is the bcrypt cost used for new and re-hashed passwords.
+// Higher than bcrypt.DefaultCost (10); older hashes are upgraded lazily on
+// successful login (see rehashIfWeak).
+const bcryptWorkFactor = 12
+
 // MaxEmailBytes is the RFC 5321 maximum length for an email address.
 const MaxEmailBytes = 254
 
@@ -31,7 +36,7 @@ const MaxEmailBytes = 254
 var dummyBcryptHash = mustGenerateDummyHash()
 
 func mustGenerateDummyHash() []byte {
-	h, err := bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), bcrypt.DefaultCost)
+	h, err := bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), bcryptWorkFactor)
 	if err != nil {
 		panic(fmt.Sprintf("auth: pre-compute dummy hash: %v", err))
 	}
@@ -93,6 +98,8 @@ func (s *Service) Login(email, password string) (string, error) {
 		return "", ErrInvalidCredentials
 	}
 
+	s.rehashIfWeak(user.ID, user.PasswordHash, password)
+
 	sid, err := generateSessionID()
 	if err != nil {
 		return "", fmt.Errorf("generate session id: %w", err)
@@ -108,6 +115,30 @@ func (s *Service) Login(email, password string) (string, error) {
 	}
 
 	return sid, nil
+}
+
+// rehashIfWeak upgrades a stored password hash whose bcrypt cost is below the
+// current work factor. Called only after the password has been verified, so
+// the plaintext is trusted. A failure here must not fail the login (the user
+// authenticated correctly); it is logged and the old hash is kept.
+func (s *Service) rehashIfWeak(userID int64, storedHash, password string) {
+	cost, err := bcrypt.Cost([]byte(storedHash))
+	if err != nil {
+		log.Printf("auth: read bcrypt cost for user %d: %v", userID, err)
+		return
+	}
+	if cost >= bcryptWorkFactor {
+		return
+	}
+
+	newHash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptWorkFactor)
+	if err != nil {
+		log.Printf("auth: re-hash password for user %d: %v", userID, err)
+		return
+	}
+	if _, err := s.db.Exec("UPDATE users SET password_hash = ? WHERE id = ?", string(newHash), userID); err != nil {
+		log.Printf("auth: persist re-hashed password for user %d: %v", userID, err)
+	}
 }
 
 func (s *Service) ValidateSession(sid string) (*User, error) {
@@ -152,7 +183,7 @@ func (s *Service) CreateUser(email, password string) error {
 	if len([]byte(password)) > bcryptMaxPasswordBytes {
 		return ErrPasswordTooLong
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptWorkFactor)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/LiukScot/dashboard/internal/db"
 )
@@ -126,6 +127,77 @@ func TestValidateSessionExpiredReturnsExpiredAndPrunes(t *testing.T) {
 
 	_, err = svc.ValidateSession(sid)
 	assert.ErrorIs(t, err, ErrSessionNotFound, "expired session should be pruned")
+}
+
+func TestCreateUserUsesWorkFactorCost(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	require.NoError(t, svc.CreateUser("cost@example.com", "pw"))
+
+	var hash string
+	require.NoError(t, svc.db.QueryRow(
+		"SELECT password_hash FROM users WHERE email = ?", "cost@example.com",
+	).Scan(&hash))
+
+	cost, err := bcrypt.Cost([]byte(hash))
+	require.NoError(t, err)
+	assert.Equal(t, bcryptWorkFactor, cost, "new users hashed at current work factor")
+}
+
+func TestLoginUpgradesWeakHashLazily(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	// Seed a user whose hash uses an outdated, weaker cost (pre-upgrade).
+	weakCost := bcryptWorkFactor - 2
+	weakHash, err := bcrypt.GenerateFromPassword([]byte("correct horse"), weakCost)
+	require.NoError(t, err)
+	_, err = svc.db.Exec(
+		"INSERT INTO users (email, password_hash) VALUES (?, ?)",
+		"legacy@example.com", string(weakHash),
+	)
+	require.NoError(t, err)
+
+	// A successful login must transparently re-hash at the new work factor.
+	_, err = svc.Login("legacy@example.com", "correct horse")
+	require.NoError(t, err)
+
+	var stored string
+	require.NoError(t, svc.db.QueryRow(
+		"SELECT password_hash FROM users WHERE email = ?", "legacy@example.com",
+	).Scan(&stored))
+
+	cost, err := bcrypt.Cost([]byte(stored))
+	require.NoError(t, err)
+	assert.Equal(t, bcryptWorkFactor, cost, "weak hash upgraded on login")
+	assert.NotEqual(t, string(weakHash), stored, "stored hash actually changed")
+
+	// The upgraded hash must still verify the same password.
+	_, err = svc.Login("legacy@example.com", "correct horse")
+	assert.NoError(t, err, "login works after re-hash")
+}
+
+func TestLoginDoesNotRehashCurrentCost(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	require.NoError(t, svc.CreateUser("stable@example.com", "pw"))
+
+	var before string
+	require.NoError(t, svc.db.QueryRow(
+		"SELECT password_hash FROM users WHERE email = ?", "stable@example.com",
+	).Scan(&before))
+
+	_, err := svc.Login("stable@example.com", "pw")
+	require.NoError(t, err)
+
+	var after string
+	require.NoError(t, svc.db.QueryRow(
+		"SELECT password_hash FROM users WHERE email = ?", "stable@example.com",
+	).Scan(&after))
+
+	assert.Equal(t, before, after, "hash already at work factor is not rewritten")
 }
 
 func TestCreateUserRejectsDuplicateEmail(t *testing.T) {

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -156,6 +157,7 @@ func (c *CronCollector) Week(start time.Time) (CronWeek, error) {
 	if warnings == nil {
 		warnings = []string{}
 	}
+	warnings = sanitizeWarnings(warnings)
 	historyByOccurrence := map[string]CronHistoryItem{}
 	for _, item := range history {
 		historyByOccurrence[item.JobID+"\x00"+item.ScheduledAt] = item
@@ -894,6 +896,39 @@ func txInsertHistory(tx *sql.Tx, jobID string, observedAt time.Time, status stri
 
 func historyKey(user string, command string) string {
 	return strings.TrimSpace(user) + "\x00" + strings.TrimSpace(command)
+}
+
+// rawLogLineSuffix matches the ` (line: "...")` fragment that some warnings
+// append to surface the offending log entry while debugging. That fragment is
+// a verbatim journalctl/syslog line — it can carry usernames, full commands,
+// and free-text message bodies — so it is stripped before the warning leaves
+// the server (AGENTS.md §10: no PII in API output).
+var rawLogLineSuffix = regexp.MustCompile(` \(line: ".*"\)$`)
+
+// absolutePathRe matches POSIX absolute paths so they can be reduced to their
+// basename. Exposing full filesystem layout to the browser leaks host
+// structure (which dirs exist, where spools/configs live).
+var absolutePathRe = regexp.MustCompile(`/[^\s:()"]+`)
+
+// sanitizeWarning strips PII and host-path detail from a single cron warning
+// while keeping the diagnostic shape (what failed, which kind of source).
+func sanitizeWarning(warning string) string {
+	warning = rawLogLineSuffix.ReplaceAllString(warning, "")
+	return absolutePathRe.ReplaceAllStringFunc(warning, func(path string) string {
+		base := filepath.Base(path)
+		if base == "" || base == "." || base == "/" {
+			return path
+		}
+		return base
+	})
+}
+
+func sanitizeWarnings(warnings []string) []string {
+	out := make([]string, len(warnings))
+	for i, w := range warnings {
+		out[i] = sanitizeWarning(w)
+	}
+	return out
 }
 
 func dayKeys(start time.Time, count int) []string {

--- a/internal/collectors/cron_test.go
+++ b/internal/collectors/cron_test.go
@@ -3,6 +3,7 @@ package collectors
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,5 +250,46 @@ func TestParseCronLogLineUsesRequestedWeekYear(t *testing.T) {
 	}
 	if observedAt.Year() != 2024 {
 		t.Fatalf("expected prior year inference, got %s", observedAt.Format(time.RFC3339))
+	}
+}
+
+func TestSanitizeWarningStripsRawLogLine(t *testing.T) {
+	t.Parallel()
+
+	in := `insert history ab12 at 2025-01-02T03:04:05Z from journalctl: disk full (line: "Jan  2 03:04:05 host CRON[42]: (luca) CMD (/home/luca/secret.sh)")`
+	got := sanitizeWarning(in)
+
+	if strings.Contains(got, "line:") {
+		t.Fatalf("raw log line fragment not stripped: %q", got)
+	}
+	if strings.Contains(got, "luca") || strings.Contains(got, "secret.sh") {
+		t.Fatalf("PII from log line leaked: %q", got)
+	}
+	if !strings.Contains(got, "disk full") {
+		t.Fatalf("diagnostic detail should be kept: %q", got)
+	}
+}
+
+func TestSanitizeWarningReducesAbsolutePathsToBasename(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeWarning("read /var/spool/cron/luca: permission denied")
+	if strings.Contains(got, "/var/spool/cron") {
+		t.Fatalf("absolute path not reduced: %q", got)
+	}
+	if !strings.Contains(got, "luca") {
+		t.Fatalf("basename should be retained for diagnostics: %q", got)
+	}
+	if !strings.Contains(got, "permission denied") {
+		t.Fatalf("error detail should be kept: %q", got)
+	}
+}
+
+func TestSanitizeWarningLeavesPlainTextUntouched(t *testing.T) {
+	t.Parallel()
+
+	in := "unsupported cron nickname \"@reboot\""
+	if got := sanitizeWarning(in); got != in {
+		t.Fatalf("plain warning altered: %q -> %q", in, got)
 	}
 }

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -43,21 +42,27 @@ type ContainerStats struct {
 }
 
 type DockerCollector struct {
-	client *http.Client
+	client   *http.Client
+	streamer *StatsStreamer
 }
 
-const maxConcurrentStatsRequests = 4
-
 func NewDockerCollector(socketPath string) *DockerCollector {
+	// The list/one-shot client keeps a request timeout. The streamer needs a
+	// client WITHOUT a timeout: a streaming /stats connection stays open
+	// indefinitely, so a per-request deadline would kill it. Both dial the
+	// same unix socket.
+	dial := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return net.Dial("unix", socketPath)
+	}
+	streamClient := &http.Client{
+		Transport: &http.Transport{DialContext: dial},
+	}
 	return &DockerCollector{
 		client: &http.Client{
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", socketPath)
-				},
-			},
-			Timeout: 10 * time.Second,
+			Transport: &http.Transport{DialContext: dial},
+			Timeout:   10 * time.Second,
 		},
+		streamer: NewStatsStreamer(streamClient),
 	}
 }
 
@@ -148,53 +153,34 @@ func isValidContainerID(id string) bool {
 	return true
 }
 
-func (d *DockerCollector) GetContainerStats(containerID string) (*ContainerStats, error) {
-	if !isValidContainerID(containerID) {
-		return nil, fmt.Errorf("invalid container id %q", containerID)
-	}
-	resp, err := d.client.Get(fmt.Sprintf("http://docker/%s/containers/%s/stats?stream=false", dockerAPIVersion, containerID))
-	if err != nil {
-		return nil, fmt.Errorf("docker stats %s: %w", containerID, err)
-	}
-	defer resp.Body.Close()
+// rawContainerStats is the subset of the Docker stats JSON we consume. The
+// streaming reader decodes this shape once per pushed frame.
+type rawContainerStats struct {
+	Name     string `json:"name"`
+	CPUStats struct {
+		CPUUsage struct {
+			TotalUsage uint64 `json:"total_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage uint64 `json:"system_cpu_usage"`
+		OnlineCPUs     int    `json:"online_cpus"`
+	} `json:"cpu_stats"`
+	PreCPUStats struct {
+		CPUUsage struct {
+			TotalUsage uint64 `json:"total_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage uint64 `json:"system_cpu_usage"`
+	} `json:"precpu_stats"`
+	MemoryStats struct {
+		Usage uint64 `json:"usage"`
+		Limit uint64 `json:"limit"`
+	} `json:"memory_stats"`
+	Networks map[string]struct {
+		RxBytes uint64 `json:"rx_bytes"`
+		TxBytes uint64 `json:"tx_bytes"`
+	} `json:"networks"`
+}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read stats body: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("docker stats %s: unexpected status %d", containerID, resp.StatusCode)
-	}
-
-	var raw struct {
-		Name     string `json:"name"`
-		CPUStats struct {
-			CPUUsage struct {
-				TotalUsage uint64 `json:"total_usage"`
-			} `json:"cpu_usage"`
-			SystemCPUUsage uint64 `json:"system_cpu_usage"`
-			OnlineCPUs     int    `json:"online_cpus"`
-		} `json:"cpu_stats"`
-		PreCPUStats struct {
-			CPUUsage struct {
-				TotalUsage uint64 `json:"total_usage"`
-			} `json:"cpu_usage"`
-			SystemCPUUsage uint64 `json:"system_cpu_usage"`
-		} `json:"precpu_stats"`
-		MemoryStats struct {
-			Usage uint64 `json:"usage"`
-			Limit uint64 `json:"limit"`
-		} `json:"memory_stats"`
-		Networks map[string]struct {
-			RxBytes uint64 `json:"rx_bytes"`
-			TxBytes uint64 `json:"tx_bytes"`
-		} `json:"networks"`
-	}
-
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("decode stats: %w", err)
-	}
-
+func (raw rawContainerStats) toContainerStats(containerID string) ContainerStats {
 	// Guard uint64 subtraction; counters can drop on container restart or
 	// stats reset, and wrap-around would surface as nonsense CPU%.
 	var cpuDelta, systemDelta float64
@@ -225,7 +211,7 @@ func (d *DockerCollector) GetContainerStats(containerID string) (*ContainerStats
 		memPercent = 100.0 * float64(raw.MemoryStats.Usage) / float64(raw.MemoryStats.Limit)
 	}
 
-	return &ContainerStats{
+	return ContainerStats{
 		ID:         containerID,
 		Name:       name,
 		CPUPercent: cpuPercent,
@@ -234,9 +220,14 @@ func (d *DockerCollector) GetContainerStats(containerID string) (*ContainerStats
 		MemPercent: memPercent,
 		NetRx:      netRx,
 		NetTx:      netTx,
-	}, nil
+	}
 }
 
+// GetAllStats lists running containers and returns their latest stats from the
+// streaming cache. The first call for a freshly seen container opens its stream
+// and may return it without stats until the first frame arrives (~1s); steady
+// state reads are served entirely from memory, with no per-container HTTP call
+// per tick.
 func (d *DockerCollector) GetAllStats() ([]ContainerStats, error) {
 	containers, err := d.ListContainers()
 	if err != nil {
@@ -251,39 +242,10 @@ func (d *DockerCollector) GetAllStats() ([]ContainerStats, error) {
 		running = append(running, c)
 	}
 
-	stats := make([]ContainerStats, len(running))
-	filled := make([]bool, len(running))
-	sem := make(chan struct{}, maxConcurrentStatsRequests)
+	return d.streamer.Snapshot(running), nil
+}
 
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-	for i, c := range running {
-		wg.Add(1)
-		go func(i int, c Container) {
-			defer wg.Done()
-
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			s, err := d.GetContainerStats(c.ID)
-			if err != nil {
-				return
-			}
-
-			mu.Lock()
-			stats[i] = *s
-			filled[i] = true
-			mu.Unlock()
-		}(i, c)
-	}
-	wg.Wait()
-
-	result := make([]ContainerStats, 0, len(running))
-	for i, ok := range filled {
-		if ok {
-			result = append(result, stats[i])
-		}
-	}
-
-	return result, nil
+// Close stops all background stats streams. Call on shutdown.
+func (d *DockerCollector) Close() {
+	d.streamer.Close()
 }

--- a/internal/collectors/docker_stream.go
+++ b/internal/collectors/docker_stream.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // StatsStreamer removes the per-tick N+1 in docker stats collection. Instead of
@@ -24,6 +25,15 @@ import (
 type StatsStreamer struct {
 	client *http.Client
 
+	// staleAfter drops a cached frame from Snapshot once it is older than this,
+	// so a wedged stream surfaces as "no data" instead of frozen numbers.
+	staleAfter time.Duration
+	// reconnectBackoff is the minimum gap before a dropped/errored stream is
+	// re-opened, so a container whose /stats keeps failing doesn't hot-loop.
+	reconnectBackoff time.Duration
+	// now is overridable in tests to control staleness/backoff timing.
+	now func() time.Time
+
 	mu      sync.Mutex
 	streams map[string]*statsStream
 }
@@ -31,38 +41,69 @@ type StatsStreamer struct {
 type statsStream struct {
 	cancel context.CancelFunc
 
-	mu      sync.Mutex
-	latest  ContainerStats
-	hasData bool
+	mu        sync.Mutex
+	latest    ContainerStats
+	hasData   bool
+	updatedAt time.Time
+	// done is set when run() exits (drop, EOF, non-200). A done-but-wanted
+	// stream is re-opened by the next reconcile.
+	done bool
+	// notBefore gates re-opening after an exit, implementing backoff.
+	notBefore time.Time
 }
 
-func (s *statsStream) store(stats ContainerStats) {
+func (s *statsStream) store(stats ContainerStats, at time.Time) {
 	s.mu.Lock()
 	s.latest = stats
 	s.hasData = true
+	s.updatedAt = at
 	s.mu.Unlock()
 }
 
-func (s *statsStream) read() (ContainerStats, bool) {
+func (s *statsStream) read() (ContainerStats, bool, time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.latest, s.hasData
+	return s.latest, s.hasData, s.updatedAt
 }
+
+func (s *statsStream) markDone(notBefore time.Time) {
+	s.mu.Lock()
+	s.done = true
+	s.notBefore = notBefore
+	s.mu.Unlock()
+}
+
+func (s *statsStream) canReopen(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.done && !now.Before(s.notBefore)
+}
+
+const (
+	defaultStatsStaleAfter       = 15 * time.Second
+	defaultStatsReconnectBackoff = 5 * time.Second
+)
 
 func NewStatsStreamer(client *http.Client) *StatsStreamer {
 	return &StatsStreamer{
-		client:  client,
-		streams: make(map[string]*statsStream),
+		client:           client,
+		staleAfter:       defaultStatsStaleAfter,
+		reconnectBackoff: defaultStatsReconnectBackoff,
+		now:              time.Now,
+		streams:          make(map[string]*statsStream),
 	}
 }
 
 // Snapshot reconciles the set of live streams against the currently running
 // containers, then returns the latest cached stats for those that have produced
-// at least one frame. A container that just started (no frame yet) is simply
-// omitted until its first frame arrives, matching the prior behaviour where a
-// failed stats fetch dropped the container from the result.
+// at least one frame within staleAfter. A container that just started (no frame
+// yet) or whose stream has wedged (frame older than staleAfter) is omitted,
+// matching the prior behaviour where a failed stats fetch dropped the container
+// from the result.
 func (st *StatsStreamer) Snapshot(running []Container) []ContainerStats {
 	st.reconcile(running)
+
+	now := st.now()
 
 	st.mu.Lock()
 	streamsByID := make(map[string]*statsStream, len(st.streams))
@@ -77,8 +118,8 @@ func (st *StatsStreamer) Snapshot(running []Container) []ContainerStats {
 		if !ok {
 			continue
 		}
-		stats, hasData := s.read()
-		if !hasData {
+		stats, hasData, updatedAt := s.read()
+		if !hasData || now.Sub(updatedAt) > st.staleAfter {
 			continue
 		}
 		// Names can change; the list endpoint is authoritative for them.
@@ -97,6 +138,8 @@ func (st *StatsStreamer) reconcile(running []Container) {
 		wanted[c.ID] = true
 	}
 
+	now := st.now()
+
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -111,14 +154,25 @@ func (st *StatsStreamer) reconcile(running []Container) {
 		if !isValidContainerID(c.ID) {
 			continue
 		}
-		if _, ok := st.streams[c.ID]; ok {
-			continue
+		if existing, ok := st.streams[c.ID]; ok {
+			// Still-running container whose stream died: re-open it once its
+			// backoff window has elapsed. A live stream is left alone.
+			if !existing.canReopen(now) {
+				continue
+			}
+			existing.cancel()
+			delete(st.streams, c.ID)
 		}
-		ctx, cancel := context.WithCancel(context.Background())
-		s := &statsStream{cancel: cancel}
-		st.streams[c.ID] = s
-		go st.run(ctx, c.ID, s)
+		st.startStream(c.ID)
 	}
+}
+
+// startStream creates a stream entry and launches its reader. Caller holds st.mu.
+func (st *StatsStreamer) startStream(containerID string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &statsStream{cancel: cancel}
+	st.streams[containerID] = s
+	go st.run(ctx, containerID, s)
 }
 
 // Close tears down every active stream. Safe to call on shutdown.
@@ -133,9 +187,17 @@ func (st *StatsStreamer) Close() {
 
 // run holds one streaming /stats connection open and decodes frames as Docker
 // pushes them, storing the latest into the shared cache. It returns when ctx is
-// cancelled (container stopped or shutdown) or the connection drops; in the
-// drop case the next reconcile re-opens it.
+// cancelled (container stopped or shutdown) or the connection drops/errors. On
+// any non-cancelled exit it marks the stream done with a backoff deadline, so
+// the next reconcile re-opens it for a still-running container without
+// hot-looping on a persistently failing endpoint.
 func (st *StatsStreamer) run(ctx context.Context, containerID string, s *statsStream) {
+	defer func() {
+		if ctx.Err() == nil {
+			s.markDone(st.now().Add(st.reconnectBackoff))
+		}
+	}()
+
 	url := fmt.Sprintf("http://docker/%s/containers/%s/stats?stream=true", dockerAPIVersion, containerID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -153,6 +215,8 @@ func (st *StatsStreamer) run(ctx context.Context, containerID string, s *statsSt
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// Drain so the transport can reuse the connection.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		log.Printf("docker stats stream %s: unexpected status %d", containerID, resp.StatusCode)
 		return
 	}
@@ -169,6 +233,6 @@ func (st *StatsStreamer) run(ctx context.Context, containerID string, s *statsSt
 			}
 			return
 		}
-		s.store(raw.toContainerStats(containerID))
+		s.store(raw.toContainerStats(containerID), st.now())
 	}
 }

--- a/internal/collectors/docker_stream.go
+++ b/internal/collectors/docker_stream.go
@@ -1,0 +1,174 @@
+package collectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+)
+
+// StatsStreamer removes the per-tick N+1 in docker stats collection. Instead of
+// issuing one one-shot `/stats?stream=false` request per container on every
+// broadcast tick — each of which makes the Docker daemon collect twice with a
+// ~1s gap to compute CPU deltas — it keeps a single long-lived streaming
+// connection per running container. Docker pushes a fresh stats frame roughly
+// once per second on that connection; the latest frame is cached, so a
+// broadcast tick reads memory instead of fanning out N blocking HTTP calls.
+//
+// The Docker Engine API has no aggregate stats endpoint, so one connection per
+// container is the minimum; the win is that connections are reused across ticks
+// rather than re-opened every tick.
+type StatsStreamer struct {
+	client *http.Client
+
+	mu      sync.Mutex
+	streams map[string]*statsStream
+}
+
+type statsStream struct {
+	cancel context.CancelFunc
+
+	mu      sync.Mutex
+	latest  ContainerStats
+	hasData bool
+}
+
+func (s *statsStream) store(stats ContainerStats) {
+	s.mu.Lock()
+	s.latest = stats
+	s.hasData = true
+	s.mu.Unlock()
+}
+
+func (s *statsStream) read() (ContainerStats, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latest, s.hasData
+}
+
+func NewStatsStreamer(client *http.Client) *StatsStreamer {
+	return &StatsStreamer{
+		client:  client,
+		streams: make(map[string]*statsStream),
+	}
+}
+
+// Snapshot reconciles the set of live streams against the currently running
+// containers, then returns the latest cached stats for those that have produced
+// at least one frame. A container that just started (no frame yet) is simply
+// omitted until its first frame arrives, matching the prior behaviour where a
+// failed stats fetch dropped the container from the result.
+func (st *StatsStreamer) Snapshot(running []Container) []ContainerStats {
+	st.reconcile(running)
+
+	st.mu.Lock()
+	streamsByID := make(map[string]*statsStream, len(st.streams))
+	for id, s := range st.streams {
+		streamsByID[id] = s
+	}
+	st.mu.Unlock()
+
+	result := make([]ContainerStats, 0, len(running))
+	for _, c := range running {
+		s, ok := streamsByID[c.ID]
+		if !ok {
+			continue
+		}
+		stats, hasData := s.read()
+		if !hasData {
+			continue
+		}
+		// Names can change; the list endpoint is authoritative for them.
+		stats.ID = c.ID
+		if c.Name != "" {
+			stats.Name = c.Name
+		}
+		result = append(result, stats)
+	}
+	return result
+}
+
+func (st *StatsStreamer) reconcile(running []Container) {
+	wanted := make(map[string]bool, len(running))
+	for _, c := range running {
+		wanted[c.ID] = true
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	for id := range st.streams {
+		if !wanted[id] {
+			st.streams[id].cancel()
+			delete(st.streams, id)
+		}
+	}
+
+	for _, c := range running {
+		if !isValidContainerID(c.ID) {
+			continue
+		}
+		if _, ok := st.streams[c.ID]; ok {
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		s := &statsStream{cancel: cancel}
+		st.streams[c.ID] = s
+		go st.run(ctx, c.ID, s)
+	}
+}
+
+// Close tears down every active stream. Safe to call on shutdown.
+func (st *StatsStreamer) Close() {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for id, s := range st.streams {
+		s.cancel()
+		delete(st.streams, id)
+	}
+}
+
+// run holds one streaming /stats connection open and decodes frames as Docker
+// pushes them, storing the latest into the shared cache. It returns when ctx is
+// cancelled (container stopped or shutdown) or the connection drops; in the
+// drop case the next reconcile re-opens it.
+func (st *StatsStreamer) run(ctx context.Context, containerID string, s *statsStream) {
+	url := fmt.Sprintf("http://docker/%s/containers/%s/stats?stream=true", dockerAPIVersion, containerID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Printf("docker stats stream %s: build request: %v", containerID, err)
+		return
+	}
+
+	resp, err := st.client.Do(req)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("docker stats stream %s: %v", containerID, err)
+		}
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("docker stats stream %s: unexpected status %d", containerID, resp.StatusCode)
+		return
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		var raw rawContainerStats
+		if err := decoder.Decode(&raw); err != nil {
+			if ctx.Err() == nil && err != io.EOF {
+				log.Printf("docker stats stream %s: decode: %v", containerID, err)
+			}
+			return
+		}
+		s.store(raw.toContainerStats(containerID))
+	}
+}

--- a/internal/collectors/docker_stream.go
+++ b/internal/collectors/docker_stream.go
@@ -34,6 +34,8 @@ type StatsStreamer struct {
 	// now is overridable in tests to control staleness/backoff timing.
 	now func() time.Time
 
+	// Lock ordering: always StatsStreamer.mu before statsStream.mu, never the
+	// reverse, to avoid deadlock when reconcile holds st.mu and inspects a stream.
 	mu      sync.Mutex
 	streams map[string]*statsStream
 }

--- a/internal/collectors/docker_stream_test.go
+++ b/internal/collectors/docker_stream_test.go
@@ -1,0 +1,210 @@
+package collectors
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock is a manually advanced clock for deterministic staleness/backoff.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1_700_000_000, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+func streamerForTest(t *testing.T, mux *http.ServeMux) *StatsStreamer {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	addr := strings.TrimPrefix(server.URL, "http://")
+	dial := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", addr)
+	}
+	st := NewStatsStreamer(&http.Client{Transport: &http.Transport{DialContext: dial}})
+	t.Cleanup(st.Close)
+	return st
+}
+
+func waitForStreamDone(t *testing.T, st *StatsStreamer, id string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		st.mu.Lock()
+		s, ok := st.streams[id]
+		st.mu.Unlock()
+		if ok {
+			s.mu.Lock()
+			done := s.done
+			s.mu.Unlock()
+			if done {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("stream %s never marked done", id)
+}
+
+func TestStreamerReopensDroppedStreamOnReconcile(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/stats") {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&hits, 1)
+		// Serve exactly one frame, then return so the connection drops (EOF).
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(statsFrame("test", 200, 100, 400, 200))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Returning here closes the response body → reader sees EOF.
+	})
+
+	st := streamerForTest(t, mux)
+	clock := newFakeClock()
+	st.now = clock.now
+	st.reconnectBackoff = 0 // re-open immediately once done
+
+	id := "aaaaaaaaaaaa"
+	container := []Container{{ID: id, Name: "alpha"}}
+
+	st.Snapshot(container)
+	waitForStreamDone(t, st, id)
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 connection before reconnect, got %d", got)
+	}
+
+	// The container is still running; the next reconcile must re-open the
+	// dropped stream rather than serving a frozen frame forever.
+	st.Snapshot(container)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&hits) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&hits); got < 2 {
+		t.Fatalf("dropped stream was not re-opened on reconcile; hits=%d", got)
+	}
+}
+
+func TestStreamerOmitsStaleFrame(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/stats") {
+			http.NotFound(w, r)
+			return
+		}
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(statsFrame("test", 200, 100, 400, 200))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	})
+
+	st := streamerForTest(t, mux)
+	clock := newFakeClock()
+	st.now = clock.now
+	st.staleAfter = 10 * time.Second
+
+	id := "aaaaaaaaaaaa"
+	container := []Container{{ID: id, Name: "alpha"}}
+
+	// Wait until a frame is cached (stored with clock's current time).
+	deadline := time.Now().Add(2 * time.Second)
+	var fresh []ContainerStats
+	for time.Now().Before(deadline) {
+		fresh = st.Snapshot(container)
+		if len(fresh) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(fresh) != 1 {
+		t.Fatalf("expected fresh frame to be served, got %d", len(fresh))
+	}
+
+	// Advance past the staleness window without any new frame: the wedged
+	// stream must surface as "no data".
+	clock.advance(11 * time.Second)
+	if stale := st.Snapshot(container); len(stale) != 0 {
+		t.Fatalf("expected stale frame to be omitted, got %d", len(stale))
+	}
+}
+
+func TestStreamerBacksOffFailingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/stats") {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusNotFound) // persistent failure
+	})
+
+	st := streamerForTest(t, mux)
+	clock := newFakeClock()
+	st.now = clock.now
+	st.reconnectBackoff = 30 * time.Second
+
+	id := "aaaaaaaaaaaa"
+	container := []Container{{ID: id, Name: "alpha"}}
+
+	st.Snapshot(container)
+	waitForStreamDone(t, st, id)
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 attempt, got %d", got)
+	}
+
+	// Within the backoff window, reconcile must NOT hammer the endpoint.
+	st.Snapshot(container)
+	st.Snapshot(container)
+	time.Sleep(100 * time.Millisecond)
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected no reconnect during backoff, got %d hits", got)
+	}
+
+	// Past the backoff window, reconcile re-attempts.
+	clock.advance(31 * time.Second)
+	st.Snapshot(container)
+	waitForStreamDone(t, st, id)
+	if got := atomic.LoadInt32(&hits); got < 2 {
+		t.Fatalf("expected reconnect after backoff elapsed, got %d hits", got)
+	}
+}

--- a/internal/collectors/docker_test.go
+++ b/internal/collectors/docker_test.go
@@ -11,7 +11,60 @@ import (
 	"time"
 )
 
-func TestGetAllStatsCollectsRunningContainersInParallel(t *testing.T) {
+// statsFrame is the minimal Docker stats object the streaming reader decodes.
+func statsFrame(name string, totalUsage, preTotal, sysUsage, preSys uint64) map[string]any {
+	return map[string]any{
+		"name": name,
+		"cpu_stats": map[string]any{
+			"cpu_usage":        map[string]any{"total_usage": totalUsage},
+			"system_cpu_usage": sysUsage,
+			"online_cpus":      2,
+		},
+		"precpu_stats": map[string]any{
+			"cpu_usage":        map[string]any{"total_usage": preTotal},
+			"system_cpu_usage": preSys,
+		},
+		"memory_stats": map[string]any{"usage": 100, "limit": 400},
+		"networks":     map[string]any{"eth0": map[string]any{"rx_bytes": 10, "tx_bytes": 20}},
+	}
+}
+
+func testCollector(t *testing.T, mux *http.ServeMux) *DockerCollector {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	addr := strings.TrimPrefix(server.URL, "http://")
+	dial := func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", addr)
+	}
+	streamClient := &http.Client{Transport: &http.Transport{DialContext: dial}}
+	c := &DockerCollector{
+		client:   &http.Client{Transport: &http.Transport{DialContext: dial}, Timeout: time.Second},
+		streamer: NewStatsStreamer(streamClient),
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+func eventuallyStats(t *testing.T, c *DockerCollector, want int) []ContainerStats {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats, err := c.GetAllStats()
+		if err != nil {
+			t.Fatalf("GetAllStats: %v", err)
+		}
+		if len(stats) >= want {
+			return stats
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("stats cache never reached %d entries", want)
+	return nil
+}
+
+func TestGetAllStatsStreamsRunningContainers(t *testing.T) {
 	t.Parallel()
 
 	mux := http.NewServeMux()
@@ -20,70 +73,92 @@ func TestGetAllStatsCollectsRunningContainersInParallel(t *testing.T) {
 			{"Id": "aaaaaaaaaaaa1111", "Names": []string{"/alpha"}, "State": "running", "Status": "Up"},
 			{"Id": "bbbbbbbbbbbb2222", "Names": []string{"/beta"}, "State": "running", "Status": "Up"},
 			{"Id": "cccccccccccc3333", "Names": []string{"/gamma"}, "State": "running", "Status": "Up"},
+			{"Id": "dddddddddddd4444", "Names": []string{"/stopped"}, "State": "exited", "Status": "Exited"},
 		}
 		if err := json.NewEncoder(w).Encode(containers); err != nil {
 			t.Fatalf("encode containers: %v", err)
 		}
 	})
+	// Streaming stats endpoint: emit a couple of frames then keep the
+	// connection open (the reader caches the latest frame).
 	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/stats") {
 			http.NotFound(w, r)
 			return
 		}
-
-		time.Sleep(150 * time.Millisecond)
-		stats := map[string]any{
-			"name": "test",
-			"cpu_stats": map[string]any{
-				"cpu_usage":        map[string]any{"total_usage": 200},
-				"system_cpu_usage": 400,
-				"online_cpus":      2,
-			},
-			"precpu_stats": map[string]any{
-				"cpu_usage":        map[string]any{"total_usage": 100},
-				"system_cpu_usage": 200,
-			},
-			"memory_stats": map[string]any{
-				"usage": 100,
-				"limit": 400,
-			},
-			"networks": map[string]any{
-				"eth0": map[string]any{"rx_bytes": 10, "tx_bytes": 20},
-			},
+		flusher, _ := w.(http.Flusher)
+		enc := json.NewEncoder(w)
+		for i := 0; i < 2; i++ {
+			if err := enc.Encode(statsFrame("test", 200, 100, 400, 200)); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
 		}
-		if err := json.NewEncoder(w).Encode(stats); err != nil {
-			t.Fatalf("encode stats: %v", err)
-		}
+		<-r.Context().Done()
 	})
 
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
+	collector := testCollector(t, mux)
 
-	addr := strings.TrimPrefix(server.URL, "http://")
-	collector := &DockerCollector{
-		client: &http.Client{
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "tcp", addr)
-				},
-			},
-			Timeout: time.Second,
-		},
-	}
-
-	start := time.Now()
-	stats, err := collector.GetAllStats()
-	if err != nil {
-		t.Fatalf("GetAllStats: %v", err)
-	}
-	elapsed := time.Since(start)
-
+	// First call opens streams; data arrives asynchronously, so poll until the
+	// cache fills. Only the 3 running containers should ever appear.
+	stats := eventuallyStats(t, collector, 3)
 	if len(stats) != 3 {
-		t.Fatalf("expected stats for 3 containers, got %d", len(stats))
+		t.Fatalf("expected stats for 3 running containers, got %d", len(stats))
 	}
-	if elapsed >= 300*time.Millisecond {
-		t.Fatalf("expected parallel collection under 300ms, got %s", elapsed)
+	for _, s := range stats {
+		if s.CPUPercent <= 0 {
+			t.Fatalf("expected computed cpu%% for %s, got %v", s.ID, s.CPUPercent)
+		}
+		if s.MemPercent != 25 {
+			t.Fatalf("expected mem%% 25, got %v", s.MemPercent)
+		}
+	}
+}
+
+func TestStatsStreamerReconcileStopsRemovedContainers(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1.43/containers/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/stats") {
+			http.NotFound(w, r)
+			return
+		}
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(statsFrame("test", 200, 100, 400, 200))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	})
+
+	collector := testCollector(t, mux)
+	streamer := collector.streamer
+
+	alpha := Container{ID: "aaaaaaaaaaaa", Name: "alpha"}
+	beta := Container{ID: "bbbbbbbbbbbb", Name: "beta"}
+
+	streamer.Snapshot([]Container{alpha, beta})
+	streamer.mu.Lock()
+	openAfterStart := len(streamer.streams)
+	streamer.mu.Unlock()
+	if openAfterStart != 2 {
+		t.Fatalf("expected 2 streams, got %d", openAfterStart)
+	}
+
+	// beta disappears; its stream must be torn down.
+	streamer.Snapshot([]Container{alpha})
+	streamer.mu.Lock()
+	_, betaStillOpen := streamer.streams[beta.ID]
+	openAfterRemove := len(streamer.streams)
+	streamer.mu.Unlock()
+	if betaStillOpen {
+		t.Fatal("expected beta stream to be removed after reconcile")
+	}
+	if openAfterRemove != 1 {
+		t.Fatalf("expected 1 stream after removal, got %d", openAfterRemove)
 	}
 }
 
@@ -120,37 +195,5 @@ func TestListContainersReturnsErrorOnHTTPFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "500") || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected error to include status and body, got: %v", err)
-	}
-}
-
-func TestGetContainerStatsReturnsErrorOnHTTPFailure(t *testing.T) {
-	t.Parallel()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1.43/containers/missing/stats", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		if err := json.NewEncoder(w).Encode(map[string]string{"message": "container not found"}); err != nil {
-			t.Fatalf("encode error payload: %v", err)
-		}
-	})
-
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	addr := strings.TrimPrefix(server.URL, "http://")
-	collector := &DockerCollector{
-		client: &http.Client{
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					var d net.Dialer
-					return d.DialContext(ctx, "tcp", addr)
-				},
-			},
-			Timeout: time.Second,
-		},
-	}
-
-	if _, err := collector.GetContainerStats("missing"); err == nil {
-		t.Fatal("expected HTTP failure to return error")
 	}
 }

--- a/internal/collectors/system_history.go
+++ b/internal/collectors/system_history.go
@@ -31,6 +31,16 @@ const (
 	secondsPerDay  = 86400
 	bucket5mSecs   = 5 * 60
 	bucket1hSecs   = secondsPerHour
+
+	// maxHistoryRows bounds a single Query() to the number of samples the
+	// retention policy can legitimately keep: 1m for 24h, 5m for 7d, 1h for
+	// 30d, with headroom for the brief overlap before downsampling runs. It
+	// stops a stalled retention loop (or an over-wide range) from loading
+	// tens of thousands of rows into memory at once (AGENTS.md §12).
+	maxHistoryRows = (retain1mHours * 60) +
+		(retain5mDays * 24 * (secondsPerHour / bucket5mSecs)) +
+		(retain1hDays * 24) +
+		1000
 )
 
 type SystemHistory struct {
@@ -218,13 +228,22 @@ func (h *SystemHistory) downsample(srcRes, dstRes string, cutoff, bucketSec int6
 func (h *SystemHistory) Query(rangeDur time.Duration) ([]HistorySample, error) {
 	since := time.Now().Add(-rangeDur).Unix()
 
+	// Bound the scan to the newest maxHistoryRows so a stalled retention loop
+	// can't pull tens of thousands of rows into memory; the inner DESC+LIMIT
+	// keeps the most recent samples, the outer ASC restores chart order.
 	rows, err := h.db.Query(
 		`SELECT timestamp, resolution, cpu_percent, mem_percent, disk_percent,
 				swap_percent, net_rx_rate, net_tx_rate, load_avg_1
-		   FROM metrics_history
-		  WHERE timestamp >= ?
+		   FROM (
+				SELECT timestamp, resolution, cpu_percent, mem_percent, disk_percent,
+					   swap_percent, net_rx_rate, net_tx_rate, load_avg_1
+				  FROM metrics_history
+				 WHERE timestamp >= ?
+				 ORDER BY timestamp DESC
+				 LIMIT ?
+		   )
 		  ORDER BY timestamp ASC`,
-		since,
+		since, maxHistoryRows,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/collectors/system_history_test.go
+++ b/internal/collectors/system_history_test.go
@@ -320,3 +320,30 @@ func TestQueryFiltersByDuration(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.InDelta(t, 11.0, out[0].CPUPercent, 0.01)
 }
+
+func TestQueryBoundsResultToMaxHistoryRows(t *testing.T) {
+	db := newHistoryTestDB(t)
+	h := &SystemHistory{db: db}
+
+	now := time.Now().Unix()
+	// Insert more 1m samples inside the window than the bound allows. Each ts
+	// is a distinct minute so dedupe does not collapse them.
+	overflow := maxHistoryRows + 50
+	for i := 0; i < overflow; i++ {
+		insertSample(t, db, now-int64(i*60), resolution1m, float64(i))
+	}
+
+	samples, err := h.Query(60 * 24 * time.Hour)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(samples), maxHistoryRows, "result must be bounded")
+
+	// Ascending order is the chart contract.
+	for i := 1; i < len(samples); i++ {
+		assert.LessOrEqual(t, samples[i-1].Timestamp, samples[i].Timestamp, "ascending order")
+	}
+
+	// The kept rows must be the newest ones (DESC+LIMIT then ASC), so the last
+	// sample is the most recent (i==0 insert, timestamp == now).
+	assert.Equal(t, now, samples[len(samples)-1].Timestamp, "newest sample retained")
+}


### PR DESCRIPTION
Implements the approved deferred findings from #74 in one branch.

## Findings

1. **bcrypt cost 10→12 + lazy re-hash** (`internal/auth/auth.go`)
   New const `bcryptWorkFactor = 12` used for new users, the dummy timing
   hash, and re-hashing. On a successful login, if the stored hash's
   `bcrypt.Cost` is below the work factor, the verified password is
   re-hashed and persisted. Re-hash failure is logged, never fails the
   login. Tests: new-user cost, lazy upgrade, no-op when already current.

2. **CronWeek.Warnings PII** (`internal/collectors/cron.go`) — **sanitize path**.
   The frontend *does* render `week.warnings` verbatim
   (`cron/+page.svelte`), so `json:"-"` was not an option. Warnings are
   sanitized before leaving the server: the embedded raw log line
   (`(line: "...")` — journalctl/syslog content with usernames/commands)
   is stripped, and absolute paths are reduced to their basename. Tests
   cover all three cases.

3. **TimeChart hex colors → CSS tokens** (`frontend/src/components/TimeChart.svelte`)
   Colors are read at runtime from the `--color-*` custom properties via
   `getComputedStyle(document.documentElement)` in `onMount` (client-only
   SPA). Hardcoded hex remain only as a pre-mount fallback.

4. **Docker stats N+1** (`internal/collectors/docker*.go`, ws hub) — **HIGH**.
   The Docker Engine API has **no aggregate stats endpoint**, so the
   "single batched fetch" isn't possible at the API level. Instead, the
   per-tick N+1 (one one-shot `stream=false` request per container every
   3s, each forcing a ~1s double-collection in the daemon) is removed by
   keeping one long-lived `stream=true` connection per running container
   and caching the latest frame. Broadcast ticks now read from memory;
   a reconcile step opens/closes streams as containers come and go.
   Steady-state ticks issue zero per-container HTTP. See the D2 note below.

5. **system_history SELECT without LIMIT** (`internal/collectors/system_history.go`)
   `Query` now bounds the scan to `maxHistoryRows` (derived from the
   30-day retention constants) via inner `DESC + LIMIT` / outer `ASC`,
   so it keeps the newest samples in chart order and never loads ~43k
   rows at once.

6. **Test gaps** (frontend)
   Added Vitest coverage for the WebSocket client (`ws.test.ts`),
   `formatBytes` (`format.test.ts`), and the toast store including the
   auto-dismiss timer with fake timers (`toast.svelte.test.ts`).

## D2 decision (Docker N+1)

I verified there is no aggregate/batch stats endpoint in the Docker
Engine API — `/containers/{id}/stats` is the only one, and `docker stats`
itself fans out per container. So rather than "one batched call", the fix
reuses connections: a persistent streaming connection per container with
an in-memory latest-frame cache, reconciled each tick. This eliminates
the per-tick HTTP fan-out (the actual N+1) and the expensive one-shot
double-collection. Tradeoff: one goroutine + one open connection per
running container (the API floor), torn down on stop/shutdown.

The now-unused one-shot `GetContainerStats` was removed per AGENTS.md §17;
its JSON parsing is shared with the streaming reader.

## Verification

- `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./...` ✓ (134 tests, also green under `-race`)
- frontend: `bun install` ✓ · `bun run build` ✓ · `bun run test` ✓ (38 tests, 7 files) · `svelte-check` 0 errors / 0 warnings

Note: there is no `lint` script in `frontend/package.json` and CI does
not run one; `svelte-check` (the project's type/lint gate) is clean.

Part of #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)