### PR TITLE
fix: graceful shutdown so deferred cleanup runs on exit

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/LiukScot/dashboard/internal/auth"
@@ -13,16 +16,25 @@ import (
 )
 
 func main() {
+	// run() owns all deferred cleanup; main() only translates the result into an
+	// exit code. log.Fatal calls os.Exit, which skips defers, so it must never
+	// run while cleanup is pending.
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	cfg := config.Load()
 
 	database, err := db.Open(cfg.DBPath)
 	if err != nil {
-		log.Fatalf("failed to open database: %v", err)
+		return err
 	}
 	defer database.Close()
 
 	if err := db.RunMigrations(database); err != nil {
-		log.Fatalf("failed to run migrations: %v", err)
+		return err
 	}
 
 	authSvc := auth.NewService(database, cfg.SessionTTL)
@@ -34,11 +46,15 @@ func main() {
 	logColl := collectors.NewLogCollector(cfg.LogPath)
 	cronColl := collectors.NewCronCollector(database, cfg.CronPaths, cfg.LogPath)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// SIGINT/SIGTERM cancels the root context, which drains the HTTP server and
+	// stops the background collectors so the deferred Close calls actually run.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	sysHist.Run(ctx)
 
 	srv := server.New(cfg, authSvc, sysColl, sysHist, dockerColl, f2bColl, logColl, cronColl)
 
-	log.Fatal(srv.Start(ctx))
+	// Start returns nil on a clean ctx-driven shutdown and an error only on a
+	// real serve failure (e.g. the port is already bound).
+	return srv.Start(ctx)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,10 +110,19 @@ func (s *Server) routes() {
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	// Cancel on every return path (graceful shutdown OR serve failure) so the
+	// broadcast loop and cleanup goroutine always stop. The cancel must run
+	// before the <-done join, otherwise a serve failure (ctx not yet cancelled
+	// by the caller) would block forever waiting on a loop that never exits.
+	ctx, cancel := context.WithCancel(ctx)
+
 	// Start WebSocket broadcast; ctx cancellation stops the loop and its ticker
 	// on shutdown so neither the goroutine nor the ticker leaks.
 	done := s.wsHandler.StartBroadcastLoop(ctx, 3*time.Second)
-	defer func() { <-done }()
+	defer func() {
+		cancel()
+		<-done
+	}()
 
 	go func() {
 		ticker := time.NewTicker(time.Hour)
@@ -149,8 +158,33 @@ func (s *Server) Start(ctx context.Context) error {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	return srv.ListenAndServe()
+
+	// ListenAndServe blocks until the server stops, so run it in a goroutine and
+	// select against ctx so a cancelled root context triggers a graceful drain.
+	serveErr := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			serveErr <- err
+			return
+		}
+		serveErr <- nil
+	}()
+
+	select {
+	case err := <-serveErr:
+		// Server stopped on its own (bind failure or crash) before shutdown.
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("graceful shutdown: %w", err)
+		}
+		return nil
+	}
 }
+
+const shutdownTimeout = 15 * time.Second
 
 const hstsMaxAgeSeconds = 365 * 24 * 3600
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -60,6 +60,85 @@ func loginUser(t *testing.T, srv *Server, email, password string) string {
 
 // --- /api/v1/auth/login -----------------------------------------------------
 
+// freePort reserves an ephemeral port and releases it, returning a port that is
+// free at this instant. Good enough for a single-shot start/stop test.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// TestStartShutsDownOnContextCancel proves the graceful-shutdown wiring: Start
+// blocks while serving, and a cancelled context makes it drain and return nil
+// (not block forever, not error). This is what lets main()'s deferred cleanup
+// run instead of being skipped by an os.Exit.
+func TestStartShutsDownOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Host: "127.0.0.1", Port: freePort(t), SessionTTL: 3600}
+	srv := startTestServer(t, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx) }()
+
+	// Give the listener a moment to bind, then signal shutdown.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(shutdownTimeout + 2*time.Second):
+		t.Fatal("Start did not return after context cancel")
+	}
+}
+
+// startTestServer builds the minimal Server that Start touches.
+func startTestServer(t *testing.T, cfg *config.Config) *Server {
+	t.Helper()
+	hub := NewHub()
+	srv := &Server{
+		cfg:        cfg,
+		authSvc:    auth.NewService(nil, cfg.SessionTTL),
+		sysColl:    collectors.NewSystemCollector(""),
+		dockerColl: collectors.NewDockerCollector(""),
+		mux:        http.NewServeMux(),
+		startedAt:  time.Now(),
+	}
+	srv.wsHandler = NewWSHandler(hub, srv.authSvc, srv.sysColl, srv.dockerColl, cfg)
+	return srv
+}
+
+// TestStartReturnsErrorWhenPortBound proves Start returns the bind error
+// instead of hanging. The broadcast loop only stops on ctx cancel, so Start
+// must cancel its own derived context on the serve-failure path; otherwise the
+// <-done join would deadlock and Start would never return.
+func TestStartReturnsErrorWhenPortBound(t *testing.T) {
+	t.Parallel()
+
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = blocker.Close() })
+	port := blocker.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.Config{Host: "127.0.0.1", Port: port, SessionTTL: 3600}
+	srv := startTestServer(t, cfg)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(context.Background()) }()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start hung on bind failure instead of returning the error")
+	}
+}
+
 func TestHandleLoginRejectsOversizedBody(t *testing.T) {
 	t.Parallel()
 	srv := newTestServer(t, nil, nil)


### PR DESCRIPTION
## Problem

`cmd/dashboard/main.go` wrapped the server in `log.Fatal(srv.Start(ctx))`.
`log.Fatal` calls `os.Exit`, and **`os.Exit` skips every deferred call**. So
on shutdown none of these ever ran:

- `defer cancel()` — never cancelled the root context
- `defer database.Close()`
- `defer dockerColl.Close()` — the docker stats streamer teardown

It wasn't a leak (the OS reaps the process on exit), but the cleanup path was
effectively dead code and there was no graceful HTTP shutdown — in-flight
requests were cut mid-flight.

## Fix

- **Signal-based root context**: `main` now uses
  `signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)`. SIGINT/SIGTERM
  cancels the root context.
- **Defers actually run**: all setup + defers moved into `run() error`. `main`
  only maps the result to an exit code via `log.Fatal(run())`. `log.Fatal` no
  longer runs while cleanup is pending — a clean shutdown returns `nil`, exits
  0, and runs every defer (`cancel`, `database.Close`, `dockerColl.Close`); a
  real startup error still exits non-zero.
- **Graceful HTTP drain**: `Server.Start` runs `ListenAndServe` in a goroutine
  and selects on `ctx.Done()`. On cancel it calls `http.Server.Shutdown` with a
  15s timeout and returns `nil`; on a serve failure (e.g. port already bound) it
  returns the error.
- **Deadlock fix exposed by the above**: `Start`'s `<-done` join waits for the
  WebSocket broadcast loop, which only stops on ctx cancel. On the serve-failure
  path the caller's ctx isn't cancelled, so the join would block forever. `Start`
  now derives its own cancellable context and cancels it on every return path.
  The old `log.Fatal`/`os.Exit` masked this because it never reached the join.

## Cleanups that now run on shutdown

`database.Close()`, `dockerColl.Close()` (docker stats streamer teardown), root
context `cancel`/`stop` (stops `sysHist.Run`, the WS broadcast loop, and the
session-cleanup goroutine), plus a graceful HTTP `Shutdown` that drains in-flight
requests.

## Tests

- `TestStartShutsDownOnContextCancel`: server binds, ctx cancel makes `Start`
  drain and return `nil` promptly (not hang, not error).
- `TestStartReturnsErrorWhenPortBound`: bind failure makes `Start` return the
  error instead of deadlocking on the broadcast-loop join.

`go build ./... && go vet ./... && go test -race ./...` all green. `gofmt -l`
clean on all changed files.