### PR TITLE
fix: codebase analysis findings 2026-06-20

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@ LOG_PATH=/var/log
 DOCKER_SOCKET=/var/run/docker.sock
 CRON_PATHS=/etc/crontab,/etc/cron.d/*,/var/spool/cron/*,/var/spool/cron/crontabs/*,/var/spool/cron/tabs/*
 ALLOWED_ORIGINS=http://localhost:4200,http://127.0.0.1:4200,http://localhost:5173,http://127.0.0.1:5173
-COOKIE_SECURE=false  # set to true in production (requires HTTPS/reverse proxy)
+COOKIE_SECURE=true   # requires HTTPS / reverse proxy; set to false only for localhost dev
 SESSION_TTL=2592000
 PUBLIC_DIR=./frontend/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1"
 
       - name: Cache Bun dependencies
         uses: actions/cache@v5
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1"
 
       - name: Install frontend dependencies
         run: bun install
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1"
 
       - name: Install root deps
         run: bun install

--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1"
 
       - name: Refresh frontend lockfile
         working-directory: frontend

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,7 +47,7 @@ export const api = {
 		params.set('limit', String(limit));
 		return request<LogEntry[]>(`/api/v1/security/logs?${params}`);
 	},
-	cronWeek: (start: string) => request<CronWeek>(`/api/v1/cron/week?start=${start}`),
+	cronWeek: (start: string) => request<CronWeek>(`/api/v1/cron/week?start=${encodeURIComponent(start)}`),
 	hideCronJob: (fingerprint: string) =>
 		request<{ status: string }>(`/api/v1/cron/jobs/${encodeURIComponent(fingerprint)}/hide`, {
 			method: 'POST'

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,6 +1,13 @@
+export const BYTES_PER_KB = 1024;
+
 export function formatBytes(bytes: number): string {
 	if (bytes <= 0) return '0 B';
 	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-	const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-	return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+	const i = Math.min(Math.floor(Math.log(bytes) / Math.log(BYTES_PER_KB)), units.length - 1);
+	return `${(bytes / Math.pow(BYTES_PER_KB, i)).toFixed(1)} ${units[i]}`;
+}
+
+/** Round to one decimal place. */
+export function round1dp(x: number): number {
+	return Math.round(x * 10) / 10;
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 	} from '$lib/api';
 	import { subscribe, type MetricsMessage } from '$lib/ws';
 	import { toastError } from '$lib/stores/toast.svelte';
-	import { formatBytes } from '$lib/format';
+	import { formatBytes, round1dp, BYTES_PER_KB } from '$lib/format';
 	import GaugeRing from '../components/GaugeRing.svelte';
 	import ContainerTable from '../components/ContainerTable.svelte';
 
@@ -72,8 +72,8 @@
 	const metricChartSeries = $derived.by(() => {
 		const m = metrics[selectedMetric];
 		const data = historyLive
-			? liveHistory.map((p) => Math.round(m.live(p) * 10) / 10)
-			: historySamples.map((s) => Math.round(m.hist(s) * 10) / 10);
+			? liveHistory.map((p) => round1dp(m.live(p)))
+			: historySamples.map((s) => round1dp(m.hist(s)));
 		return [{ name: `${m.label} %`, data, color: m.color }];
 	});
 	const netChartLabels = $derived(
@@ -86,24 +86,24 @@
 			? [
 					{
 						name: 'Download',
-						data: netHistory.map((h) => Math.round(h.rx * 10) / 10),
+						data: netHistory.map((h) => round1dp(h.rx)),
 						color: '#4488ff'
 					},
 					{
 						name: 'Upload',
-						data: netHistory.map((h) => Math.round(h.tx * 10) / 10),
+						data: netHistory.map((h) => round1dp(h.tx)),
 						color: '#00d4aa'
 					}
 				]
 			: [
 					{
 						name: 'Download',
-						data: historySamples.map((s) => Math.round((s.netRxRate / 1024) * 10) / 10),
+						data: historySamples.map((s) => round1dp(s.netRxRate / BYTES_PER_KB)),
 						color: '#4488ff'
 					},
 					{
 						name: 'Upload',
-						data: historySamples.map((s) => Math.round((s.netTxRate / 1024) * 10) / 10),
+						data: historySamples.map((s) => round1dp(s.netTxRate / BYTES_PER_KB)),
 						color: '#00d4aa'
 					}
 				]
@@ -173,8 +173,8 @@
 			}));
 			netHistory = netSeed.slice(-netHistoryCap).map((s) => ({
 				time: new Date(s.timestamp * 1000).toLocaleTimeString(),
-				rx: s.netRxRate / 1024,
-				tx: s.netTxRate / 1024
+				rx: s.netRxRate / BYTES_PER_KB,
+				tx: s.netTxRate / BYTES_PER_KB
 			}));
 		} catch (err) {
 			toastError(err, 'Failed to load system overview');
@@ -214,8 +214,8 @@
 					...netHistory.slice(-(netHistoryCap - 1)),
 					{
 						time: new Date().toLocaleTimeString(),
-						rx: total.rx / 1024,
-						tx: total.tx / 1024
+						rx: total.rx / BYTES_PER_KB,
+						tx: total.tx / BYTES_PER_KB
 					}
 				];
 			}
@@ -227,10 +227,14 @@
 		unsubscribeWs?.();
 	});
 
+	const SECONDS_PER_DAY = 86400;
+	const SECONDS_PER_HOUR = 3600;
+	const SECONDS_PER_MINUTE = 60;
+
 	function formatUptime(seconds: number): string {
-		const d = Math.floor(seconds / 86400);
-		const h = Math.floor((seconds % 86400) / 3600);
-		const m = Math.floor((seconds % 3600) / 60);
+		const d = Math.floor(seconds / SECONDS_PER_DAY);
+		const h = Math.floor((seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR);
+		const m = Math.floor((seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
 		if (d > 0) return `${d}d ${h}h ${m}m`;
 		if (h > 0) return `${h}h ${m}m`;
 		return `${m}m`;

--- a/frontend/src/routes/cron/+page.svelte
+++ b/frontend/src/routes/cron/+page.svelte
@@ -63,9 +63,24 @@
 		return week?.days ?? Array.from({ length: 7 }, (_, index) => toDateInput(addDays(weekStart, index)));
 	}
 
+	// Pre-group occurrences by dayKey so each column lookup is O(1) instead of
+	// scanning the full occurrence list for every day in the 7-column render loop.
+	const occurrencesByDay = $derived.by(() => {
+		const map = new Map<string, CronOccurrence[]>();
+		if (!week) return map;
+		for (const occ of week.occurrences) {
+			const list = map.get(occ.dayKey);
+			if (list) {
+				list.push(occ);
+			} else {
+				map.set(occ.dayKey, [occ]);
+			}
+		}
+		return map;
+	});
+
 	function occurrencesForDay(dayKey: string) {
-		if (!week) return [];
-		return week.occurrences.filter((occurrence) => occurrence.dayKey === dayKey);
+		return occurrencesByDay.get(dayKey) ?? [];
 	}
 
 	function occurrenceStyle(occurrence: CronOccurrence) {

--- a/internal/collectors/cron.go
+++ b/internal/collectors/cron.go
@@ -19,6 +19,10 @@ import (
 
 const maxHistoryMessageBytes = 512
 
+// maxHistoryQueryRows bounds the number of history rows returned per week
+// query so a large DB cannot cause unbounded memory allocation.
+const maxHistoryQueryRows = 5000
+
 type CronCollector struct {
 	db      *sql.DB
 	paths   []string
@@ -670,8 +674,8 @@ func (c *CronCollector) history(start time.Time, end time.Time) ([]CronHistoryIt
 		 FROM cron_run_history
 		 WHERE scheduled_at >= ? AND scheduled_at < ?
 		 ORDER BY scheduled_at ASC
-		 LIMIT 5000`,
-		start.Format(time.RFC3339), end.Format(time.RFC3339),
+		 LIMIT ?`,
+		start.Format(time.RFC3339), end.Format(time.RFC3339), maxHistoryQueryRows,
 	)
 	if err != nil {
 		return nil, err
@@ -736,6 +740,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 		func() {
 			defer func() { _ = file.Close() }()
 			scanner := bufio.NewScanner(file)
+			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 			for scanner.Scan() {
 				line := scanner.Text()
 				observedAt, user, command, ok := parseCronLogLine(line, reference)
@@ -750,7 +755,7 @@ func (c *CronCollector) importLogHistory(jobs []CronJob, start time.Time, end ti
 				if len(msg) > maxHistoryMessageBytes {
 					msg = msg[:maxHistoryMessageBytes]
 				}
-				if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", logFile, msg); err != nil {
+				if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", filepath.Base(logFile), msg); err != nil {
 					warnings = append(warnings, fmt.Sprintf("insert history %s at %s from %s: %v (line: %q)", job.Fingerprint, observedAt.Format(time.RFC3339), logFile, err, line))
 				} else {
 					imported++
@@ -811,8 +816,10 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 	imported := 0
 	var warnings []string
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		observedAt, user, command, ok := parseCronLogLine(scanner.Text(), end.Add(-time.Second))
+		line := scanner.Text()
+		observedAt, user, command, ok := parseCronLogLine(line, end.Add(-time.Second))
 		if !ok || observedAt.Before(start) || !observedAt.Before(end) {
 			continue
 		}
@@ -820,8 +827,12 @@ func (c *CronCollector) importJournalHistory(byCommand map[string]CronJob, start
 		if !exists {
 			continue
 		}
-		if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", "journalctl", scanner.Text()); err != nil {
-			warnings = append(warnings, fmt.Sprintf("insert history %s at %s from journalctl: %v (line: %q)", job.Fingerprint, observedAt.Format(time.RFC3339), err, scanner.Text()))
+		msg := line
+		if len(msg) > maxHistoryMessageBytes {
+			msg = msg[:maxHistoryMessageBytes]
+		}
+		if err := txInsertHistory(tx, job.Fingerprint, observedAt, "observed", "journalctl", msg); err != nil {
+			warnings = append(warnings, fmt.Sprintf("insert history %s at %s from journalctl: %v (line: %q)", job.Fingerprint, observedAt.Format(time.RFC3339), err, line))
 		} else {
 			imported++
 		}

--- a/internal/collectors/docker.go
+++ b/internal/collectors/docker.go
@@ -7,10 +7,21 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
 const dockerAPIVersion = "v1.43"
+
+// dockerShortIDLen is the length of the abbreviated container ID returned by
+// Docker's list endpoint (first 12 hex chars of the full SHA-256 ID).
+const dockerShortIDLen = 12
+
+// trimContainerName strips the leading "/" that Docker prepends to container
+// names in the list and stats endpoints.
+func trimContainerName(name string) string {
+	return strings.TrimPrefix(name, "/")
+}
 
 type Container struct {
 	ID      string            `json:"id"`
@@ -105,10 +116,7 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 	for i, c := range raw {
 		name := ""
 		if len(c.Names) > 0 {
-			name = c.Names[0]
-			if len(name) > 0 && name[0] == '/' {
-				name = name[1:]
-			}
+			name = trimContainerName(c.Names[0])
 		}
 
 		ports := make([]ContainerPort, len(c.Ports))
@@ -122,8 +130,8 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 		}
 
 		id := c.Id
-		if len(id) > 12 {
-			id = id[:12]
+		if len(id) > dockerShortIDLen {
+			id = id[:dockerShortIDLen]
 		}
 
 		containers[i] = Container{
@@ -142,7 +150,7 @@ func (d *DockerCollector) ListContainers() ([]Container, error) {
 }
 
 func isValidContainerID(id string) bool {
-	if len(id) != 12 {
+	if len(id) != dockerShortIDLen {
 		return false
 	}
 	for _, c := range id {
@@ -201,10 +209,7 @@ func (raw rawContainerStats) toContainerStats(containerID string) ContainerStats
 		netTx += n.TxBytes
 	}
 
-	name := raw.Name
-	if len(name) > 0 && name[0] == '/' {
-		name = name[1:]
-	}
+	name := trimContainerName(raw.Name)
 
 	memPercent := 0.0
 	if raw.MemoryStats.Limit > 0 {

--- a/internal/collectors/fail2ban.go
+++ b/internal/collectors/fail2ban.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -52,19 +53,40 @@ func (f *Fail2BanCollector) GetStatus() (*Fail2BanStatus, error) {
 	}
 
 	jailNames := parseJailList(string(out))
-	status := &Fail2BanStatus{}
 
-	for _, name := range jailNames {
+	type result struct {
+		jail *JailStatus
+		err  error
+	}
+	results := make([]result, len(jailNames))
+	var wg sync.WaitGroup
+	for i, name := range jailNames {
 		if !validJailName.MatchString(name) {
 			continue
 		}
-		jail, err := f.getJailStatus(name)
-		if err != nil {
-			log.Printf("fail2ban: get jail %q status: %v", name, err)
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			jail, err := f.getJailStatus(name)
+			results[i] = result{jail: jail, err: err}
+		}(i, name)
+	}
+	wg.Wait()
+
+	status := &Fail2BanStatus{}
+	for i, r := range results {
+		if jailNames[i] == "" || !validJailName.MatchString(jailNames[i]) {
 			continue
 		}
-		status.Jails = append(status.Jails, *jail)
-		status.TotalBans += jail.BanCount
+		if r.err != nil {
+			log.Printf("fail2ban: get jail %q status: %v", jailNames[i], r.err)
+			continue
+		}
+		if r.jail == nil {
+			continue
+		}
+		status.Jails = append(status.Jails, *r.jail)
+		status.TotalBans += r.jail.BanCount
 	}
 	status.TotalJails = len(status.Jails)
 

--- a/internal/collectors/logs.go
+++ b/internal/collectors/logs.go
@@ -10,6 +10,15 @@ import (
 	"time"
 )
 
+const (
+	// syslogTimestampLen is the character width of the standard syslog timestamp
+	// format "Jan  2 15:04:05" (note the two-char day field).
+	syslogTimestampLen = 15
+	// isoTimestampLen is the character width of the ISO-8601 prefix we accept,
+	// e.g. "2006-01-02T15:04:05" (25 chars including the T separator).
+	isoTimestampLen = 25
+)
+
 type LogEntry struct {
 	Timestamp     string `json:"timestamp"`
 	Unit          string `json:"unit"`
@@ -51,7 +60,7 @@ func (l *LogCollector) GetLogs(unit string, priority int, limit int) ([]LogEntry
 	}
 
 	for _, lf := range logFiles {
-		if unit != "" && !strings.Contains(lf.unitName, unit) {
+		if unit != "" && lf.unitName != unit {
 			continue
 		}
 
@@ -120,7 +129,7 @@ func readLogFile(path string, unitName string, priorityFilter int, maxLines int)
 
 // parseSyslogLine parses common syslog format: "Mar 31 14:23:01 hostname process[pid]: message"
 func parseSyslogLine(line string, unitName string) *LogEntry {
-	if len(line) < 16 {
+	if len(line) < syslogTimestampLen+1 {
 		return nil
 	}
 
@@ -130,8 +139,8 @@ func parseSyslogLine(line string, unitName string) *LogEntry {
 	var rest string
 
 	// Standard syslog: "Apr  1 18:30:00 hostname ..."
-	if len(line) >= 15 {
-		tsStr := line[:15]
+	if len(line) >= syslogTimestampLen {
+		tsStr := line[:syslogTimestampLen]
 		t, err := time.Parse("Jan  2 15:04:05", tsStr)
 		if err == nil {
 			now := time.Now()
@@ -143,15 +152,15 @@ func parseSyslogLine(line string, unitName string) *LogEntry {
 				t = t.AddDate(-1, 0, 0)
 			}
 			ts = strconv.FormatInt(t.UnixMicro(), 10)
-			rest = strings.TrimSpace(line[15:])
+			rest = strings.TrimSpace(line[syslogTimestampLen:])
 		}
 	}
 
 	if ts == "" {
 		// Try ISO format
-		if len(line) > 25 && (line[4] == '-' || line[10] == 'T') {
-			ts = line[:25]
-			rest = strings.TrimSpace(line[25:])
+		if len(line) > isoTimestampLen && (line[4] == '-' || line[10] == 'T') {
+			ts = line[:isoTimestampLen]
+			rest = strings.TrimSpace(line[isoTimestampLen:])
 		} else {
 			// Unparseable header — drop the line. Synthesizing time.Now()
 			// as a fallback would surface unparseable old log lines as

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -68,6 +68,10 @@ var migrations = []string{
 	// index allows SQLite to use a range scan instead of a full table scan.
 	`CREATE INDEX IF NOT EXISTS idx_metrics_history_ts
 		ON metrics_history(timestamp)`,
+	// CleanupExpiredSessions deletes by expires_at; without this index the
+	// hourly cleanup and ValidateSession expiry check both do full table scans.
+	`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at
+		ON sessions(expires_at)`,
 }
 
-const SchemaVersion = 7
+const SchemaVersion = 8

--- a/internal/server/csp.go
+++ b/internal/server/csp.go
@@ -103,6 +103,8 @@ func buildCSP(scriptHashes []string) string {
 		b.WriteString(h)
 		b.WriteString("'")
 	}
-	b.WriteString("; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'")
+	// ws:/wss: are required alongside 'self' for WebSocket upgrades: the CSP3
+	// spec does not guarantee that 'self' covers wss: when the page is https:.
+	b.WriteString("; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'none'")
 	return b.String()
 }

--- a/internal/server/origin.go
+++ b/internal/server/origin.go
@@ -18,7 +18,11 @@ func parseAllowedOrigins(origins string) map[string]bool {
 	return allowed
 }
 
-func requestOriginAllowed(r *http.Request, allowed map[string]bool) bool {
+// requestOriginAllowed returns true when the request Origin header is either in
+// the explicit allowlist or matches the same host as the server. When
+// requireHTTPS is true the same-host fallback additionally rejects http: origins
+// to prevent cross-protocol requests when the app is running behind TLS.
+func requestOriginAllowed(r *http.Request, allowed map[string]bool, requireHTTPS bool) bool {
 	origin := strings.TrimSpace(r.Header.Get("Origin"))
 	if origin == "" {
 		return false
@@ -38,5 +42,11 @@ func requestOriginAllowed(r *http.Request, allowed map[string]bool) bool {
 		return false
 	}
 
-	return strings.EqualFold(originURL.Host, requestHost)
+	if !strings.EqualFold(originURL.Host, requestHost) {
+		return false
+	}
+	if requireHTTPS && originURL.Scheme != "https" {
+		return false
+	}
+	return true
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,7 +75,7 @@ func New(cfg *config.Config, authSvc *auth.Service,
 func (s *Server) routes() {
 	// Auth routes (no middleware)
 	s.mux.HandleFunc("POST /api/v1/auth/login", s.handleLogin)
-	s.mux.HandleFunc("POST /api/v1/auth/logout", s.handleLogout)
+	s.mux.HandleFunc("POST /api/v1/auth/logout", s.withAuth(s.handleLogout))
 	s.mux.HandleFunc("GET /api/v1/auth/session", s.handleSession)
 	s.mux.HandleFunc("GET /api/v1/auth/me", s.withAuth(s.handleMe))
 
@@ -188,6 +188,15 @@ const shutdownTimeout = 15 * time.Second
 
 const hstsMaxAgeSeconds = 365 * 24 * 3600
 
+// immutableCacheMaxAgeSeconds is the Cache-Control max-age for hashed static
+// assets. Independent from hstsMaxAgeSeconds — changing HSTS duration must not
+// silently alter the asset cache TTL.
+const immutableCacheMaxAgeSeconds = 365 * 24 * 3600
+
+// cronWeekMaxLookbackDays caps the ?start query parameter to prevent a distant
+// past date from triggering a very large journalctl scan.
+const cronWeekMaxLookbackDays = 90
+
 const (
 	defaultBanLimit    = 50
 	defaultLogLimit    = 100
@@ -238,7 +247,7 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if requestOriginAllowed(r, allowed) {
+		if requestOriginAllowed(r, allowed, s.cfg.CookieSecure) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
@@ -488,6 +497,10 @@ func (s *Server) handleCronWeek(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid start date"})
 			return
 		}
+		earliest := time.Now().AddDate(0, 0, -cronWeekMaxLookbackDays)
+		if parsed.Before(earliest) {
+			parsed = earliest
+		}
 		start = parsed
 	}
 
@@ -587,7 +600,7 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	if info, err := os.Stat(filePath); err == nil && !info.IsDir() {
 		// SvelteKit hashes filenames under /_app/immutable/ — safe to cache forever.
 		if strings.HasPrefix(r.URL.Path, "/_app/immutable/") {
-			w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", hstsMaxAgeSeconds))
+			w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", immutableCacheMaxAgeSeconds))
 		}
 		http.ServeFile(w, r, filePath)
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -678,7 +678,7 @@ func TestRequestOriginAllowedAllowsConfiguredOrigin(t *testing.T) {
 	req.Header.Set("Origin", "http://localhost:5173")
 
 	allowed := parseAllowedOrigins("http://localhost:4200,http://localhost:5173")
-	assert.True(t, requestOriginAllowed(req, allowed))
+	assert.True(t, requestOriginAllowed(req, allowed, false))
 }
 
 func TestRequestOriginAllowedAllowsSameHostOrigin(t *testing.T) {
@@ -688,7 +688,7 @@ func TestRequestOriginAllowedAllowsSameHostOrigin(t *testing.T) {
 	req.Header.Set("Origin", "http://100.75.217.127:4200")
 
 	allowed := parseAllowedOrigins("http://localhost:4200,http://127.0.0.1:4200")
-	assert.True(t, requestOriginAllowed(req, allowed))
+	assert.True(t, requestOriginAllowed(req, allowed, false))
 }
 
 func TestRequestOriginAllowedRejectsOtherOrigin(t *testing.T) {
@@ -698,14 +698,14 @@ func TestRequestOriginAllowedRejectsOtherOrigin(t *testing.T) {
 	req.Header.Set("Origin", "http://evil.example")
 
 	allowed := parseAllowedOrigins("http://localhost:4200,http://localhost:5173")
-	assert.False(t, requestOriginAllowed(req, allowed))
+	assert.False(t, requestOriginAllowed(req, allowed, false))
 }
 
 func TestRequestOriginAllowedRejectsEmptyOrigin(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
 	allowed := parseAllowedOrigins("http://localhost:4200")
-	assert.False(t, requestOriginAllowed(req, allowed))
+	assert.False(t, requestOriginAllowed(req, allowed, false))
 }
 
 func TestRequestOriginAllowedRejectsMalformedOrigin(t *testing.T) {
@@ -716,7 +716,7 @@ func TestRequestOriginAllowedRejectsMalformedOrigin(t *testing.T) {
 	req.Header.Set("Origin", "http://\x7f.example")
 
 	allowed := parseAllowedOrigins("http://localhost:4200")
-	assert.False(t, requestOriginAllowed(req, allowed))
+	assert.False(t, requestOriginAllowed(req, allowed, false))
 }
 
 func TestParseAllowedOriginsIgnoresBlanks(t *testing.T) {

--- a/internal/server/ws.go
+++ b/internal/server/ws.go
@@ -15,13 +15,13 @@ import (
 	"github.com/LiukScot/dashboard/internal/config"
 )
 
-func newUpgrader(allowedOrigins string) websocket.Upgrader {
+func newUpgrader(allowedOrigins string, requireHTTPS bool) websocket.Upgrader {
 	allowed := parseAllowedOrigins(allowedOrigins)
 	return websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 		CheckOrigin: func(r *http.Request) bool {
-			return requestOriginAllowed(r, allowed)
+			return requestOriginAllowed(r, allowed, requireHTTPS)
 		},
 	}
 }
@@ -99,14 +99,14 @@ func NewWSHandler(hub *Hub, authSvc *auth.Service, sysColl *collectors.SystemCol
 		authSvc:    authSvc,
 		sysColl:    sysColl,
 		dockerColl: dockerColl,
-		upgrader:   newUpgrader(cfg.AllowedOrigins),
+		upgrader:   newUpgrader(cfg.AllowedOrigins, cfg.CookieSecure),
 	}
 }
 
 // wsMaxMessageBytes caps inbound frame size to prevent a single client from
 // asking us to allocate arbitrarily large buffers (gorilla/websocket reads
 // the whole frame before returning).
-const wsMaxMessageBytes = 1 << 16
+const wsMaxMessageBytes = 1 << 16 // 64 KiB
 
 func (ws *WSHandler) HandleUpgrade(w http.ResponseWriter, r *http.Request) {
 	_, err := auth.ValidateSessionFromCookie(ws.authSvc, r)

--- a/scripts/user-cli.go
+++ b/scripts/user-cli.go
@@ -71,6 +71,9 @@ func main() {
 			}
 			fmt.Printf("%-4d %-30s %s\n", id, email, createdAt)
 		}
+		if err := rows.Err(); err != nil {
+			log.Fatalf("list users: %v", err)
+		}
 
 	default:
 		fmt.Printf("Unknown command: %s\n", os.Args[1])


### PR DESCRIPTION
## Summary

- **Security**: CSP aggiunto `ws:/wss:` per WebSocket HTTPS; CORS schema check con `requireHTTPS`; logout protetto da `withAuth`; `COOKIE_SECURE=true` di default in `.env.example`; cron `?start` clamped a 90 giorni; syslog source sanitizzato con `filepath.Base()`
- **Bugs**: Scanner buffer mancante in `importJournalHistory` + `importLogHistory` (scansione abortiva su linea >64KB); message cap in journalctl path; `rows.Err()` in user-cli; unit filter esatto in `GetLogs`; `encodeURIComponent` in `api.ts`
- **Quality**: `immutableCacheMaxAgeSeconds` separato da `hstsMaxAgeSeconds`; `maxHistoryQueryRows=5000`; `syslogTimestampLen/isoTimestampLen`; `trimContainerName` + `dockerShortIDLen`; `BYTES_PER_KB`, `round1dp`, `SECONDS_PER_*` in frontend; `wsMaxMessageBytes // 64 KiB`
- **Performance**: Index `idx_sessions_expires_at` (schema v8); fail2ban `GetStatus` parallelizzato con `sync.WaitGroup`; cron page O(N×7) → O(1) con `$derived Map`
- **Deps**: `bun-version: "1"` in CI (era `latest`)

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/dashboard/issues/80

## Sub-analyst reports

- **Security**: No rate limiting login (deferred — design choice); CORS cross-protocol fallback (shipped); CSP wss (shipped); logout CSRF (shipped); COOKIE_SECURE default (shipped); source path leak (shipped)
- **Quality**: Dual-use `hstsMaxAgeSeconds` constant (shipped); magic numbers in cron/logs/docker/frontend (shipped); `Week()` 100-line complexity (deferred — architectural)
- **Bugs**: Scanner buffer gap in journal+syslog import (shipped); password echo in user-cli (deferred — requires new dep); `rows.Err()` missing (shipped); unit filter `Contains` vs `==` (shipped)
- **Tests**: 8+ gap findings (deferred as structured issue #80); `handleHideCronJob` invalid fingerprint path (deferred)
- **Deps**: `bun-version: latest` in CI (shipped); Dockerfile bun floating tag (already tracked in prior issue); systemd in runtime (deferred #80)
- **Performance**: `sessions.expires_at` missing index (shipped); fail2ban N+1 subprocesses (shipped — parallelized); cron O(N×7) render (shipped); Docker stats N+1 (already tracked in prior issue)

---
Generated automatically by Codebase Analyst — 2026-06-20