### PR TITLE
test: deferred codebase-analyst findings (issue #80)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/collectors/logs_test.go
+++ b/internal/collectors/logs_test.go
@@ -1,11 +1,94 @@
 package collectors
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestParseSyslogLineYearRollback(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	if now.Month() == time.December {
+		t.Skip("rollback test not applicable in December")
+	}
+	// A December line parsed with the current year is in the future → rollback.
+	line := "Dec 31 23:59:59 host sshd[42]: Connection closed"
+	entry := parseSyslogLine(line, "auth")
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	us, err := strconv.ParseInt(entry.Timestamp, 10, 64)
+	if err != nil {
+		t.Fatalf("bad timestamp: %v", err)
+	}
+	got := time.UnixMicro(us)
+	if got.Year() != now.Year()-1 {
+		t.Errorf("expected year %d after rollback, got %d", now.Year()-1, got.Year())
+	}
+}
+
+// syslogTS returns a valid syslog timestamp "MMM _D HH:MM:SS" (always 15 chars).
+// Go's "Jan  2" layout produces an extra space for double-digit days, so we
+// build the string manually to match real syslog output.
+func syslogTS(t time.Time) string {
+	return fmt.Sprintf("%s %2d %02d:%02d:%02d",
+		t.Month().String()[:3], t.Day(), t.Hour(), t.Minute(), t.Second())
+}
+
+func TestGetLogsUnitFilter(t *testing.T) {
+	t.Parallel()
+	logDir := t.TempDir()
+	ts := syslogTS(time.Now())
+
+	if err := os.WriteFile(filepath.Join(logDir, "syslog"), []byte(ts+" host kernel[1]: boot message\n"), 0o644); err != nil {
+		t.Fatalf("write syslog: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(logDir, "auth.log"), []byte(ts+" host sshd[9]: auth message\n"), 0o644); err != nil {
+		t.Fatalf("write auth.log: %v", err)
+	}
+
+	coll := NewLogCollector(logDir)
+	entries, err := coll.GetLogs("auth", -1, 100)
+	if err != nil {
+		t.Fatalf("GetLogs: %v", err)
+	}
+	for _, e := range entries {
+		if e.Unit != "auth" {
+			t.Errorf("expected unit=auth, got %q", e.Unit)
+		}
+	}
+}
+
+func TestGetLogsPriorityFilter(t *testing.T) {
+	t.Parallel()
+	logDir := t.TempDir()
+	ts := syslogTS(time.Now())
+	content := ts + " host app[1]: error connecting to database\n" +
+		ts + " host app[2]: normal startup complete\n"
+	if err := os.WriteFile(filepath.Join(logDir, "syslog"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write syslog: %v", err)
+	}
+
+	coll := NewLogCollector(logDir)
+	// priority 3 = err; only the "error" line should pass
+	entries, err := coll.GetLogs("", 3, 100)
+	if err != nil {
+		t.Fatalf("GetLogs: %v", err)
+	}
+	for _, e := range entries {
+		if e.Priority > 3 {
+			t.Errorf("got entry with priority %d > 3: %q", e.Priority, e.Message)
+		}
+	}
+	if len(entries) == 0 {
+		t.Error("expected at least one error-level entry")
+	}
+}
 
 func TestReadLogFileReturnsScannerErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	t.Parallel()
+	cfg := Load()
+	if cfg.Host != "0.0.0.0" {
+		t.Errorf("Host=%q, want 0.0.0.0", cfg.Host)
+	}
+	if cfg.Port != 4200 {
+		t.Errorf("Port=%d, want 4200", cfg.Port)
+	}
+	if !cfg.CookieSecure {
+		t.Error("CookieSecure should default to true")
+	}
+	if cfg.SessionTTL != 60*60*24*30 {
+		t.Errorf("SessionTTL=%d, want %d", cfg.SessionTTL, 60*60*24*30)
+	}
+	if cfg.MetricsInterval != 60 {
+		t.Errorf("MetricsInterval=%d, want 60", cfg.MetricsInterval)
+	}
+	if len(cfg.CronPaths) == 0 {
+		t.Error("CronPaths should have defaults")
+	}
+}
+
+func TestLoadEnvOverride(t *testing.T) {
+	t.Setenv("PORT", "9999")
+	t.Setenv("COOKIE_SECURE", "false")
+	t.Setenv("SESSION_TTL", "3600")
+
+	cfg := Load()
+	if cfg.Port != 9999 {
+		t.Errorf("Port=%d, want 9999", cfg.Port)
+	}
+	if cfg.CookieSecure {
+		t.Error("CookieSecure should be false when COOKIE_SECURE=false")
+	}
+	if cfg.SessionTTL != 3600 {
+		t.Errorf("SessionTTL=%d, want 3600", cfg.SessionTTL)
+	}
+}
+
+func TestLoadCronPathsSplit(t *testing.T) {
+	t.Setenv("CRON_PATHS", "/etc/crontab,/etc/cron.d/*")
+
+	cfg := Load()
+	if len(cfg.CronPaths) != 2 {
+		t.Errorf("CronPaths len=%d, want 2: %v", len(cfg.CronPaths), cfg.CronPaths)
+	}
+	if cfg.CronPaths[0] != "/etc/crontab" {
+		t.Errorf("CronPaths[0]=%q, want /etc/crontab", cfg.CronPaths[0])
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -856,6 +856,50 @@ func TestHandleFail2BanBansReturnsEmptyWhenNoLogFile(t *testing.T) {
 	assert.Empty(t, events)
 }
 
+func TestHandleSystemHistoryReturnsSamples(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "dashboard.sqlite")
+	database, err := db.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	require.NoError(t, db.RunMigrations(database))
+
+	_, err = database.Exec(
+		`INSERT INTO metrics_history (timestamp, resolution, cpu_percent, mem_percent, disk_percent, swap_percent, net_rx_rate, net_tx_rate, load_avg_1) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		time.Now().Unix(), "1m", 42.0, 55.0, 30.0, 0.0, 100.0, 50.0, 1.2,
+	)
+	require.NoError(t, err)
+
+	srv := newTestServer(t, nil, func(s *Server) {
+		s.sysHist = collectors.NewSystemHistory(database, nil, time.Minute)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/history?range=24h", nil)
+	res := httptest.NewRecorder()
+	srv.handleSystemHistory(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	var samples []map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&samples))
+	assert.NotEmpty(t, samples)
+}
+
+func TestHandleFail2BanStatusNullWhenUnavailable(t *testing.T) {
+	// Not parallel: modifies process PATH via t.Setenv.
+	t.Setenv("PATH", t.TempDir())
+
+	srv := newTestServer(t, nil, func(s *Server) {
+		s.f2bColl = collectors.NewFail2BanCollector(t.TempDir())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/security/fail2ban", nil)
+	res := httptest.NewRecorder()
+	srv.handleFail2Ban(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "null\n", res.Body.String())
+}
+
 func TestClampedLimit(t *testing.T) {
 	t.Parallel()
 	const def = 50

--- a/scripts/user-cli.go
+++ b/scripts/user-cli.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/term"
+
 	"github.com/LiukScot/dashboard/internal/auth"
 	"github.com/LiukScot/dashboard/internal/config"
 	"github.com/LiukScot/dashboard/internal/db"
@@ -42,11 +44,21 @@ func main() {
 		email = strings.TrimSpace(email)
 
 		fmt.Print("Password: ")
-		password, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatalf("failed to read password: %v", err)
+		var password string
+		if term.IsTerminal(int(os.Stdin.Fd())) {
+			passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+			if err != nil {
+				log.Fatalf("failed to read password: %v", err)
+			}
+			fmt.Println()
+			password = strings.TrimSpace(string(passwordBytes))
+		} else {
+			pw, err := reader.ReadString('\n')
+			if err != nil {
+				log.Fatalf("failed to read password: %v", err)
+			}
+			password = strings.TrimSpace(pw)
 		}
-		password = strings.TrimSpace(password)
 
 		if err := authSvc.CreateUser(email, password); err != nil {
 			log.Fatalf("failed to create user: %v", err)


### PR DESCRIPTION
## Summary

- Hide password input in `scripts/user-cli.go` using `term.ReadPassword` (falls back to readline when stdin is not a TTY, so the existing test keeps working)
- Add `parseSyslogLine` year-rollback test: a December line parsed in January rolls back to the previous year
- Add `GetLogs` unit-filter and priority-filter integration tests
- Add `config.Load()` defaults and env-override tests
- Add `handleSystemHistory` happy-path test (inserts a DB row and verifies the handler returns it)
- Add `handleFail2Ban` null-when-unavailable test (empty PATH → no `fail2ban-client` → 200 with `null` body)

## Test plan

- [x] `go test ./...` passes locally (all 6 packages green)
- [x] New tests cover all deferred findings from issue #80

Closes #80

Co-Authored-By: claude-sonnet-4-6
100% AI / 0% Human
claude-sonnet-4-6: implemented all test coverage and the user-cli TTY fix
Human: approved decisions in previous session